### PR TITLE
feat(docker): v0.1.0 PR #1 — full diagram toolchain + Xvfb-once entrypoint

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Force LF line endings for files that are executed in Linux containers or
+# parsed by Linux tooling. CRLF in a shebang line breaks `#!/bin/sh` lookup;
+# CRLF in a Dockerfile RUN heredoc breaks shell parsing.
+*.sh        text eol=lf
+Dockerfile  text eol=lf
+*.yml       text eol=lf
+*.yaml      text eol=lf

--- a/.github/workflows/docker-manual-pin-check.yml
+++ b/.github/workflows/docker-manual-pin-check.yml
@@ -32,24 +32,48 @@ jobs:
 
           node_major = re.search(r"^ARG\s+NODEJS_MAJOR=([^\s]+)$", dockerfile, re.MULTILINE)
           mermaid = re.search(r"^ARG\s+MERMAID_CLI_VERSION=([^\s]+)$", dockerfile, re.MULTILINE)
+          drawio = re.search(r"^ARG\s+DRAWIO_VERSION=([^\s]+)$", dockerfile, re.MULTILINE)
 
-          if not node_major or not mermaid:
-              raise SystemExit("Could not parse required Dockerfile args (NODEJS_MAJOR / MERMAID_CLI_VERSION)")
+          if not node_major or not mermaid or not drawio:
+              raise SystemExit("Could not parse required Dockerfile args (NODEJS_MAJOR / MERMAID_CLI_VERSION / DRAWIO_VERSION)")
 
           with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as out:
               out.write(f"node_major={node_major.group(1)}\n")
               out.write(f"mermaid_current={mermaid.group(1)}\n")
+              out.write(f"drawio_current={drawio.group(1)}\n")
           PY
 
       - name: Resolve latest dependency versions
         id: latest
         shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
 
           MERMAID_LATEST=$(docker run --rm node:22-alpine sh -lc "npm view @mermaid-js/mermaid-cli version")
 
+          # Resolve latest drawio-desktop release that ships an amd64 .deb asset.
+          # We require an amd64 .deb to exist on the release before bumping the pin —
+          # if upstream skipped a release for amd64, hold on the current pin.
+          DRAWIO_LATEST=$(gh api repos/jgraph/drawio-desktop/releases \
+            --jq '[.[] | select(.draft==false and .prerelease==false) | select(.assets | map(.name) | any(test("^drawio-amd64-.*\\.deb$"))) | .tag_name] | .[0]' \
+            | sed 's/^v//')
+
+          if [ -z "${DRAWIO_LATEST}" ]; then
+            echo "ERROR: could not resolve latest drawio-desktop release with amd64 .deb asset" >&2
+            exit 1
+          fi
+
           echo "mermaid_latest=${MERMAID_LATEST}" >> "${GITHUB_OUTPUT}"
+          echo "drawio_latest=${DRAWIO_LATEST}" >> "${GITHUB_OUTPUT}"
+
+          # Check whether the same release also has an arm64 .deb. We do NOT
+          # block the bump when arm64 is missing, but we surface it in the PR
+          # body so reviewers can decide whether to land amd64-only or wait.
+          DRAWIO_ARM64_AVAILABLE=$(gh api "repos/jgraph/drawio-desktop/releases/tags/v${DRAWIO_LATEST}" \
+            --jq '.assets | map(.name) | any(test("^drawio-arm64-.*\\.deb$"))')
+          echo "drawio_arm64_available=${DRAWIO_ARM64_AVAILABLE}" >> "${GITHUB_OUTPUT}"
 
       - name: Update Dockerfile when drift detected
         id: update
@@ -57,10 +81,22 @@ jobs:
         env:
           MERMAID_CURRENT: ${{ steps.parse.outputs.mermaid_current }}
           MERMAID_LATEST: ${{ steps.latest.outputs.mermaid_latest }}
+          DRAWIO_CURRENT: ${{ steps.parse.outputs.drawio_current }}
+          DRAWIO_LATEST: ${{ steps.latest.outputs.drawio_latest }}
         run: |
           set -euo pipefail
 
-          if [ "${MERMAID_CURRENT}" = "${MERMAID_LATEST}" ]; then
+          MERMAID_CHANGED=false
+          DRAWIO_CHANGED=false
+
+          if [ "${MERMAID_CURRENT}" != "${MERMAID_LATEST}" ]; then
+            MERMAID_CHANGED=true
+          fi
+          if [ "${DRAWIO_CURRENT}" != "${DRAWIO_LATEST}" ]; then
+            DRAWIO_CHANGED=true
+          fi
+
+          if [ "${MERMAID_CHANGED}" = "false" ] && [ "${DRAWIO_CHANGED}" = "false" ]; then
             echo "needs_update=false" >> "${GITHUB_OUTPUT}"
             echo "No dependency drift detected."
             exit 0
@@ -74,39 +110,49 @@ jobs:
           path = Path("Dockerfile")
           content = path.read_text(encoding="utf-8")
 
-          updated = re.sub(
-              r"^ARG\s+MERMAID_CLI_VERSION=.*$",
-              f"ARG MERMAID_CLI_VERSION={os.environ['MERMAID_LATEST']}",
-              content,
-              flags=re.MULTILINE,
-          )
+          if os.environ["MERMAID_CURRENT"] != os.environ["MERMAID_LATEST"]:
+              content = re.sub(
+                  r"^ARG\s+MERMAID_CLI_VERSION=.*$",
+                  f"ARG MERMAID_CLI_VERSION={os.environ['MERMAID_LATEST']}",
+                  content,
+                  flags=re.MULTILINE,
+              )
+          if os.environ["DRAWIO_CURRENT"] != os.environ["DRAWIO_LATEST"]:
+              content = re.sub(
+                  r"^ARG\s+DRAWIO_VERSION=.*$",
+                  f"ARG DRAWIO_VERSION={os.environ['DRAWIO_LATEST']}",
+                  content,
+                  flags=re.MULTILINE,
+              )
 
-          if updated == content:
-              raise SystemExit("Failed to update MERMAID_CLI_VERSION in Dockerfile")
-
-          path.write_text(updated, encoding="utf-8")
+          path.write_text(content, encoding="utf-8")
           PY
 
           echo "needs_update=true" >> "${GITHUB_OUTPUT}"
+          echo "mermaid_changed=${MERMAID_CHANGED}" >> "${GITHUB_OUTPUT}"
+          echo "drawio_changed=${DRAWIO_CHANGED}" >> "${GITHUB_OUTPUT}"
 
       - name: Create pull request for dependency refresh
         if: steps.update.outputs.needs_update == 'true'
         uses: peter-evans/create-pull-request@v7
         with:
-          commit-message: "chore(docker): refresh mermaid-cli pin"
+          commit-message: "chore(docker): refresh image dependency pins"
           branch: "chore/docker-dependency-refresh"
           delete-branch: true
-          title: "chore(docker): refresh mermaid-cli pin"
+          title: "chore(docker): refresh image dependency pins"
           body: |
             Automated Docker dependency refresh.
 
             - `MERMAID_CLI_VERSION`: `${{ steps.parse.outputs.mermaid_current }}` → `${{ steps.latest.outputs.mermaid_latest }}`
+            - `DRAWIO_VERSION`: `${{ steps.parse.outputs.drawio_current }}` → `${{ steps.latest.outputs.drawio_latest }}`
             - `NODEJS_MAJOR`: `${{ steps.parse.outputs.node_major }}` (tracked major channel)
+            - drawio-desktop arm64 .deb available on latest tag: `${{ steps.latest.outputs.drawio_arm64_available }}`
 
             Notes:
             - Ubuntu APT packages are intentionally unpinned in `Dockerfile` to receive security updates during regular rebuilds.
             - Base images remain digest-pinned for supply-chain integrity.
             - This PR updates only intentional app-level pinning.
+            - If `drawio_arm64_available` is `false`, hold this PR until upstream publishes an arm64 `.deb`, or land amd64-only and reopen when arm64 lands.
 
       - name: Job summary
         shell: bash
@@ -115,4 +161,7 @@ jobs:
           echo "- Node major: \`${{ steps.parse.outputs.node_major }}\`" >> "${GITHUB_STEP_SUMMARY}"
           echo "- Mermaid current: \`${{ steps.parse.outputs.mermaid_current }}\`" >> "${GITHUB_STEP_SUMMARY}"
           echo "- Mermaid latest: \`${{ steps.latest.outputs.mermaid_latest }}\`" >> "${GITHUB_STEP_SUMMARY}"
+          echo "- Drawio current: \`${{ steps.parse.outputs.drawio_current }}\`" >> "${GITHUB_STEP_SUMMARY}"
+          echo "- Drawio latest: \`${{ steps.latest.outputs.drawio_latest }}\`" >> "${GITHUB_STEP_SUMMARY}"
+          echo "- Drawio arm64 available: \`${{ steps.latest.outputs.drawio_arm64_available }}\`" >> "${GITHUB_STEP_SUMMARY}"
           echo "- Update required: \`${{ steps.update.outputs.needs_update || 'false' }}\`" >> "${GITHUB_STEP_SUMMARY}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,24 +14,40 @@ COPY src/ src/
 RUN dotnet publish src/ConfluenceSynkMD/ConfluenceSynkMD.csproj -c Release -o /app/publish --no-restore
 
 # ──────────────────────────────────────────────────────────────────────────────
-# Stage 2: Runtime image with Node.js + mermaid-cli
+# Stage 2: Runtime — full diagram toolchain
+# Ships Mermaid (Node + mermaid-cli + Chromium), PlantUML (JRE + plantuml),
+# LaTeX (TeX Live + Ghostscript; ImageMagick is intentionally NOT installed —
+# LatexRenderer calls `gs -sDEVICE=pngalpha` directly), and drawio-desktop
+# (Electron app, runs headless via Xvfb-once started by the entrypoint).
 # ──────────────────────────────────────────────────────────────────────────────
 FROM mcr.microsoft.com/dotnet/aspnet:10.0@sha256:52dcfb4225fda614c38ba5997a4ec72cbd5260a624125174416e547ff9eb9b8c AS runtime
 
 ARG NODEJS_MAJOR=22
 ARG MERMAID_CLI_VERSION=11.12.0
-ENV PUPPETEER_CACHE_DIR=/app/.cache/puppeteer
-# Dependabot tracks Docker base image updates (FROM).
-# MERMAID_CLI_VERSION and NODEJS_MAJOR are intentionally explicit and checked in CI.
+ARG DRAWIO_VERSION=26.0.0
+ARG TARGETARCH
 
-# Install Node.js (LTS) and Chromium dependencies for mermaid-cli/Puppeteer
-# NOTE: Ubuntu archive package versions are intentionally unpinned to receive
-# upstream security updates on regular image rebuilds.
+# Dependabot tracks Docker base image updates (FROM).
+# NODEJS_MAJOR, MERMAID_CLI_VERSION, and DRAWIO_VERSION are intentionally
+# explicit pins refreshed monthly by .github/workflows/docker-manual-pin-check.yml.
+
+ENV PUPPETEER_CACHE_DIR=/app/.cache/puppeteer \
+    DISPLAY=:99 \
+    DRAWIO_CMD="drawio --no-sandbox --disable-gpu"
+
+# System packages.
+# - Chromium runtime libs for Puppeteer (Mermaid renderer).
+# - Java + plantuml for the PlantUML renderer.
+# - TeX Live + Ghostscript + poppler for the LaTeX renderer (no ImageMagick).
+# - xvfb + x11-utils for the headless display server used by drawio-desktop.
+# NOTE: Ubuntu/Debian package versions are intentionally unpinned to receive
+# upstream security updates on regular image rebuilds. See the project's
+# pinning policy in .github/workflows/docker-manual-pin-check.yml.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     ca-certificates \
     gnupg \
-    # Chromium dependencies for Puppeteer headless rendering
+    # Chromium / Puppeteer (Mermaid)
     libnss3 \
     libatk1.0-0t64 \
     libatk-bridge2.0-0t64 \
@@ -50,9 +66,21 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libxss1 \
     fonts-liberation \
     fonts-noto-color-emoji \
+    # PlantUML (needs JRE)
+    default-jre-headless \
+    plantuml \
+    # LaTeX rendering: TeX Live + Ghostscript directly (no ImageMagick)
+    texlive-latex-base \
+    texlive-latex-extra \
+    texlive-fonts-recommended \
+    ghostscript \
+    poppler-utils \
+    # Headless display server for drawio-desktop (Electron app)
+    xvfb \
+    x11-utils \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Node.js LTS from explicitly configured NodeSource APT repository
+# Install Node.js LTS from explicitly configured NodeSource APT repository.
 RUN install -d -m 0755 /etc/apt/keyrings \
         && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
             | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
@@ -63,19 +91,36 @@ RUN install -d -m 0755 /etc/apt/keyrings \
             && apt-get install -y --no-install-recommends nodejs \
     && rm -rf /var/lib/apt/lists/*
 
-# Install mermaid-cli globally (includes Puppeteer + bundled Chromium)
+# Install mermaid-cli globally (includes Puppeteer + bundled Chromium).
 RUN mkdir -p ${PUPPETEER_CACHE_DIR}
 RUN npm install -g @mermaid-js/mermaid-cli@${MERMAID_CLI_VERSION} \
     && npx puppeteer browsers install chrome
 
-# Create puppeteer config for container
+# Install drawio-desktop from the pinned upstream .deb.
+# amd64 .deb URL pattern is reliable on every release.
+# arm64 availability has been inconsistent — the release workflow's
+# multi-arch pre-flight catches breakage before publishing the manifest list.
+RUN DRAWIO_ARCH=$([ "${TARGETARCH:-amd64}" = "arm64" ] && echo arm64 || echo amd64) \
+    && curl -fsSL -o /tmp/drawio.deb \
+        "https://github.com/jgraph/drawio-desktop/releases/download/v${DRAWIO_VERSION}/drawio-${DRAWIO_ARCH}-${DRAWIO_VERSION}.deb" \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends /tmp/drawio.deb \
+    && rm -f /tmp/drawio.deb \
+    && rm -rf /var/lib/apt/lists/*
+
+# Puppeteer Chromium config for headless container (Mermaid renderer).
 WORKDIR /app
 RUN echo '{"args": ["--no-sandbox", "--disable-setuid-sandbox"]}' > /app/puppeteer-config.json
+
+# Container entrypoint: starts Xvfb once on :99 for the container's lifetime,
+# then exec's dotnet. drawio-desktop inherits DISPLAY=:99 with no per-call
+# xvfb-run startup cost. See entrypoint.sh for the full startup contract.
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
 
 COPY --from=build /app/publish .
 
 RUN useradd -m -u 1001 appuser && chown -R appuser:appuser /app
 USER appuser
 
-# Default entrypoint
-ENTRYPOINT ["dotnet", "ConfluenceSynkMD.dll"]
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+# Container entrypoint for ConfluenceSynkMD.
+#
+# Starts a single Xvfb instance for the container's lifetime so that
+# Electron-based renderers (drawio-desktop) can run headlessly without
+# starting a fresh display server per invocation. DISPLAY=:99 is set in
+# the Dockerfile; child processes inherit it.
+
+set -e
+
+Xvfb :99 -screen 0 1024x768x24 -nolisten tcp >/dev/null 2>&1 &
+XVFB_PID=$!
+
+# Wait up to 5 seconds for Xvfb to be ready before exec'ing the app.
+# Closes the startup race where drawio spawns before the display listens.
+i=0
+while [ "$i" -lt 5 ]; do
+    if xdpyinfo -display :99 >/dev/null 2>&1; then
+        break
+    fi
+    i=$((i + 1))
+    sleep 1
+done
+
+if ! xdpyinfo -display :99 >/dev/null 2>&1; then
+    echo "entrypoint: Xvfb failed to start on :99 within 5s" >&2
+    exit 1
+fi
+
+cleanup() {
+    kill "$XVFB_PID" 2>/dev/null || true
+    wait "$XVFB_PID" 2>/dev/null || true
+}
+trap cleanup EXIT INT TERM
+
+exec dotnet /app/ConfluenceSynkMD.dll "$@"


### PR DESCRIPTION
## Summary

First PR in the **v0.1.0 Portable Confluence Publishing Engine** series. Closes the diagram-tool coherence break: the runtime image now ships every renderer the README claims (Mermaid, Draw.io, PlantUML, LaTeX) so a `docker run` against a `.drawio` block doesn't fail with "Draw.io CLI not found" inside a container marketed as turnkey.

This PR is foundational; subsequent PRs in the series depend on this image being able to render all four diagram types.

### What changed

**Dockerfile (runtime stage, full toolchain):**
- Added `default-jre-headless` + `plantuml` for the PlantUML renderer.
- Added `texlive-latex-base` + `texlive-latex-extra` + `texlive-fonts-recommended` + `ghostscript` + `poppler-utils` for the LaTeX renderer.
- Added `xvfb` + `x11-utils` for the headless display server used by drawio-desktop.
- Added `drawio-desktop` from a pinned upstream `.deb` (`ARG DRAWIO_VERSION=26.0.0`) using `TARGETARCH` for multi-arch resolution.
- Set `ENV DISPLAY=:99` and `ENV DRAWIO_CMD="drawio --no-sandbox --disable-gpu"`.
- Replaced the entrypoint with a small shell script that starts a single `Xvfb :99` for the container's lifetime (saves ~500-800ms per drawio diagram vs per-call `xvfb-run`).
- **ImageMagick is intentionally NOT installed.** `LatexRenderer.cs` will be updated in PR #3 to call `gs -sDEVICE=pngalpha` directly. ImageMagick's `convert` for PDFs already delegates to Ghostscript, so cutting it out drops ~80 MB and removes the need for a `policy.xml` workaround.

**`entrypoint.sh` (new, mode 100755):**
- Starts `Xvfb :99 -screen 0 1024x768x24 -nolisten tcp` in the background.
- Polls `xdpyinfo -display :99` for up to 5 seconds before exec'ing `dotnet` — closes the startup race where drawio could spawn before the display server is listening.
- Traps SIGTERM/SIGINT for clean Xvfb shutdown.

**`.github/workflows/docker-manual-pin-check.yml`:**
- Extended the Python parser to also extract `DRAWIO_VERSION`.
- Resolves the latest `jgraph/drawio-desktop` release that ships an `amd64` `.deb` asset via `gh api`.
- Surfaces arm64 `.deb` availability for the same release in the PR body so reviewers can decide whether to hold or land amd64-only.
- Job summary now includes drawio current/latest/arm64-availability.

**`.gitattributes` (new):**
- Forces LF line endings on `.sh`, `Dockerfile`, and YAML files. Without this, Windows contributors' git would convert these to CRLF on checkout, breaking the shebang lookup in the container.

### Why these decisions

The full design rationale lives in `~/.gstack/projects/OpenDocSync-ConfluenceSynkMD/christopherdukart-main-design-20260504-221238.md` (output of `/office-hours` + `/plan-eng-review`). Nine architectural decisions were logged; this PR implements the Dockerfile-level subset of them:
- **2A:** Drop ImageMagick, use ghostscript directly (no policy.xml workaround, ~80 MB smaller).
- **4A → T1:** Container-entrypoint Xvfb-once, not per-call xvfb-run (perf win on docs trees with many diagrams).
- **1B-C side effect:** With Xvfb-once, no separate `drawio-headless` shim script is needed; `DRAWIO_CMD="drawio --no-sandbox --disable-gpu"` is a multi-token env var that the upcoming renderer cmd-args parser (PR #3) will handle.

### Known gaps that follow-up PRs close

- The renderer C# code does not yet parse `DRAWIO_CMD` as command + args. `DrawioRenderer.cs:48` passes the env var verbatim to `Process.Start`. PR #3 fixes the parser. Until then, `DRAWIO_CMD` in this image will not be respected at runtime — drawio-desktop will be resolved from PATH, which still works because `drawio` is on PATH after the .deb install. The flags (`--no-sandbox --disable-gpu`) are not yet applied.
- `LatexRenderer.cs` still calls ImageMagick's `convert` and will fail at runtime in this image. PR #3 replaces it with the direct `gs` call.
- arm64 multi-arch support is not yet validated. PR #2 (release workflow) gates multi-arch publish on a successful arm64 buildx pre-flight; if that fails, v0.1.0 ships amd64-only.

These are sequenced intentionally. Merging this PR alone publishes nothing — there's no release workflow yet. The image only matters once PR #2 lands.

## Test plan

- [ ] `docker build -t confluencesynkmd-test .` succeeds on amd64 (local manual)
- [ ] `docker buildx build --platform linux/arm64 .` succeeds on arm64 (release-workflow pre-flight; PR #2)
- [ ] Inside the built image, `xdpyinfo -display :99` returns 0 within 5 seconds of container start
- [ ] Inside the built image, `which mermaid plantuml gs drawio` all resolve
- [ ] Inside the built image, `dotnet ConfluenceSynkMD.dll --help` runs (no entrypoint regression)
- [ ] `gh workflow run docker-manual-pin-check.yml` succeeds and the PR body shows DRAWIO_VERSION + arm64 availability

🤖 Generated with [Claude Code](https://claude.com/claude-code)