### PR TITLE
fix(v0.1.0): hot-fix renderer cmd-args + LatexRenderer ghostscript + migration sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,4 +5,63 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
 
+This section tracks work toward the upcoming `v0.1.0` release: a portable
+Confluence publishing engine packaged as a single multi-arch Docker image
+with the full diagram toolchain (Mermaid, Draw.io, PlantUML, LaTeX) baked in.
+
+### Added
+- **Full diagram toolchain in the runtime image.** The Docker image now ships
+  Java + PlantUML, TeX Live + Ghostscript, and drawio-desktop alongside the
+  existing Node + mermaid-cli + Chromium. `--render-drawio`, `--render-plantuml`,
+  and `--render-latex` work out of the box without host-side installs.
+- **Container entrypoint with shared Xvfb display server.** `entrypoint.sh`
+  starts a single `Xvfb :99` for the container's lifetime so drawio-desktop
+  (Electron) can run headlessly without restarting the display server per
+  diagram.
+- **`DRAWIO_VERSION` Dockerfile pin** tracked monthly by
+  `.github/workflows/docker-manual-pin-check.yml` alongside the existing
+  `MERMAID_CLI_VERSION` and `NODEJS_MAJOR` pins. The refresh PR body surfaces
+  arm64 `.deb` availability for the candidate version.
+- **Renderer cmd-args parsing.** `DRAWIO_CMD`, `PLANTUML_CMD`,
+  `LATEX_PDFLATEX_CMD`, and `LATEX_GHOSTSCRIPT_CMD` env vars now accept
+  multi-token values (e.g. `xvfb-run -a drawio --no-sandbox`) via a shared
+  `RendererCommandResolver` helper. Single-binary names (the previous contract)
+  remain valid.
+- **`.gitattributes`** forcing LF line endings on `.sh`, `Dockerfile`, and YAML
+  files so contributors on Windows do not accidentally introduce CRLF in
+  Linux-target files.
+
+### Changed
+- **CLI shape: subcommand tree.** `--mode Upload|Download|LocalExport` was
+  replaced by three top-level subcommands: `upload`, `download`, `local`.
+  This matches the idiomatic System.CommandLine pattern and clears the way
+  for the `doctor` and `init` subcommands shipping later in v0.1.0.
+- **`LatexRenderer` calls Ghostscript directly.** The PDF→PNG rasterization
+  step previously delegated to ImageMagick's `convert`, which itself wraps
+  Ghostscript. Calling `gs` directly drops the ImageMagick dependency from
+  the runtime image (~80 MB) and removes the need for the `policy.xml`
+  workaround for PDF read defaults.
+- **Migration error message** for users hitting the legacy `--mode` / `--local`
+  flags now inlines the migration table instead of referencing an external
+  changelog entry.
+
+### Removed
+- **`--mode` flag** (replaced by subcommands above).
+- **`--local` flag** (replaced by the `local` subcommand).
+- **ImageMagick** from the runtime image (Ghostscript handles PDF→PNG
+  natively; no functionality lost).
+
+### Migration
+
+| Old (`--mode`) syntax        | New (subcommand) syntax |
+|------------------------------|--------------------------|
+| `--mode Upload`              | `upload`                 |
+| `--mode Download`            | `download`               |
+| `--mode LocalExport`         | `local`                  |
+| `--mode Upload --local`      | `local`                  |
+
+The binary detects the legacy syntax (including `--mode=Upload`,
+`--mode:Upload`, and bare `--local`) at startup and prints the migration
+table before exiting with code `2`. No silent failures.

--- a/README.md
+++ b/README.md
@@ -66,31 +66,30 @@ dotnet build
 
 # Upload a documentation folder to Confluence
 dotnet run --project src/ConfluenceSynkMD -- \
-  --mode Upload \
+  upload \
   --path ./docs \
   --conf-space YOUR_SPACE_KEY \
   --conf-parent-id YOUR_PAGE_ID
 
 # Download Confluence pages back to Markdown
 dotnet run --project src/ConfluenceSynkMD -- \
-  --mode Download \
+  download \
   --path ./output \
   --conf-space YOUR_SPACE_KEY \
   --conf-parent-id YOUR_PAGE_ID
 
 # Download a specific subtree by root page title
 dotnet run --project src/ConfluenceSynkMD -- \
-  --mode Download \
+  download \
   --path ./output \
   --conf-space YOUR_SPACE_KEY \
   --root-page "My Documentation"
 
 # Local export only (no API calls)
 dotnet run --project src/ConfluenceSynkMD -- \
-  --mode Upload \
+  local \
   --path ./docs \
-  --conf-space YOUR_SPACE_KEY \
-  --local
+  --conf-space YOUR_SPACE_KEY
 ```
 
 ---
@@ -133,11 +132,24 @@ Credential settings can also be passed via CLI flags (overrides environment vari
 ConfluenceSynkMD – Markdown ↔ Confluence Synchronization Tool
 ```
 
+### Subcommands
+
+ConfluenceSynkMD uses three top-level verbs that pick the synchronization direction:
+
+| Subcommand | Description |
+| :--- | :--- |
+| `upload` | Upload Markdown documents to Confluence |
+| `download` | Download Confluence pages back into Markdown |
+| `local` | Produce local Confluence Storage Format output without API calls |
+
+> **Migrating from earlier builds:** the legacy `--mode Upload\|Download\|LocalExport` flag and the standalone `--local` flag were removed in v0.1.0. Run `confluencesynkmd upload`, `download`, or `local` instead. The binary prints a friendly migration hint if it sees the old syntax.
+
 ### Core Options
+
+These apply to every subcommand:
 
 | Option | Required | Default | Description |
 | :--- | :---: | :---: | :--- |
-| `--mode <Upload\|Download\|LocalExport>` | ✅ | — | Synchronization direction |
 | `--path <path>` | ✅ | — | Local filesystem path to Markdown files |
 | `--conf-space <key>` | ✅ | — | Confluence Space Key (e.g. `DEV`) |
 | `--conf-parent-id <id>` | | — | Parent page ID for subtree operations |
@@ -150,7 +162,6 @@ ConfluenceSynkMD – Markdown ↔ Confluence Synchronization Tool
 | `--keep-hierarchy` | `true` | Preserve local directory hierarchy in Confluence |
 | `--skip-hierarchy` | `false` | Flatten all pages under the root (overrides `--keep-hierarchy`) |
 | `--skip-update` | `false` | Skip uploading pages whose content has not changed |
-| `--local` | `false` | Only produce local Confluence Storage Format output, no API calls |
 | `--no-write-back` | `false` | Don't write `<!-- confluence-page-id -->` / `<!-- confluence-space-key -->` comments back into Markdown sources after upload |
 | `--loglevel <level>` | `info` | Logging verbosity: `debug`, `info`, `warning`, `error`, `critical` |
 
@@ -232,7 +243,7 @@ docker run --rm -it `
   -e CONFLUENCE__APITOKEN `
   -v ${PWD}/docs:/workspace/docs:ro `
   confluencesynkmd `
-  --mode Upload `
+  upload `
   --path /workspace/docs `
   --conf-space YOUR_SPACE_KEY `
   --conf-parent-id YOUR_PAGE_ID
@@ -245,7 +256,7 @@ docker run --rm -it `
   -e CONFLUENCE__APITOKEN `
   -v ${PWD}/output:/workspace/output `
   confluencesynkmd `
-  --mode Download `
+  download `
   --path /workspace/output `
   --conf-space YOUR_SPACE_KEY `
   --conf-parent-id YOUR_PAGE_ID
@@ -259,7 +270,7 @@ docker run --rm -it `
   -e CONFLUENCE__APITOKEN `
   -v ${PWD}/docs:/workspace/docs:ro `
   confluencesynkmd `
-  --mode Upload `
+  upload `
   --path /workspace/docs `
   --conf-space YOUR_SPACE_KEY `
   --conf-parent-id YOUR_PAGE_ID
@@ -272,7 +283,7 @@ docker run --rm -it `
   -e CONFLUENCE__APITOKEN `
   -v ${PWD}/output:/workspace/output `
   confluencesynkmd `
-  --mode Download `
+  download `
   --path /workspace/output `
   --conf-space YOUR_SPACE_KEY `
   --conf-parent-id YOUR_PAGE_ID

--- a/docs/de/admin/docker.md
+++ b/docs/de/admin/docker.md
@@ -39,7 +39,7 @@ Das Docker-Image enthält .NET, Node.js und mermaid-cli — eine konsistente, po
       -e CONFLUENCE__APITOKEN \
       -v $(pwd)/docs:/workspace/docs:ro \
       confluencesynkmd \
-      --mode Upload \
+      upload \
       --path /workspace/docs \
       --conf-space IHR_SPACE_KEY \
       --conf-parent-id IHRE_PAGE_ID
@@ -52,7 +52,7 @@ Das Docker-Image enthält .NET, Node.js und mermaid-cli — eine konsistente, po
       -e CONFLUENCE__APITOKEN \
       -v $(pwd)/output:/workspace/output \
       confluencesynkmd \
-      --mode Download \
+      download \
       --path /workspace/output \
       --conf-space IHR_SPACE_KEY \
       --conf-parent-id IHRE_PAGE_ID
@@ -65,7 +65,7 @@ Das Docker-Image enthält .NET, Node.js und mermaid-cli — eine konsistente, po
       -e CONFLUENCE__APITOKEN \
       -v $(pwd)/docs:/workspace/docs:ro \
       confluencesynkmd \
-      --mode Upload \
+      upload \
       --path /workspace/docs \
       --conf-space IHR_SPACE_KEY \
       --conf-parent-id IHRE_PAGE_ID
@@ -78,7 +78,7 @@ Das Docker-Image enthält .NET, Node.js und mermaid-cli — eine konsistente, po
       -e CONFLUENCE__APITOKEN \
       -v $(pwd)/output:/workspace/output \
       confluencesynkmd \
-      --mode Download \
+      download \
       --path /workspace/output \
       --conf-space IHR_SPACE_KEY \
       --conf-parent-id IHRE_PAGE_ID
@@ -95,7 +95,7 @@ Das Docker-Image enthält .NET, Node.js und mermaid-cli — eine konsistente, po
       -e CONFLUENCE__APITOKEN `
       -v ${PWD}/docs:/workspace/docs:ro `
       confluencesynkmd `
-      --mode Upload `
+      upload `
       --path /workspace/docs `
       --conf-space IHR_SPACE_KEY `
       --conf-parent-id IHRE_PAGE_ID
@@ -108,7 +108,7 @@ Das Docker-Image enthält .NET, Node.js und mermaid-cli — eine konsistente, po
       -e CONFLUENCE__APITOKEN `
       -v ${PWD}/output:/workspace/output `
       confluencesynkmd `
-      --mode Download `
+      download `
       --path /workspace/output `
       --conf-space IHR_SPACE_KEY `
       --conf-parent-id IHRE_PAGE_ID
@@ -121,7 +121,7 @@ Das Docker-Image enthält .NET, Node.js und mermaid-cli — eine konsistente, po
       -e CONFLUENCE__APITOKEN `
       -v ${PWD}/docs:/workspace/docs:ro `
       confluencesynkmd `
-      --mode Upload `
+      upload `
       --path /workspace/docs `
       --conf-space IHR_SPACE_KEY `
       --conf-parent-id IHRE_PAGE_ID
@@ -134,7 +134,7 @@ Das Docker-Image enthält .NET, Node.js und mermaid-cli — eine konsistente, po
       -e CONFLUENCE__APITOKEN `
       -v ${PWD}/output:/workspace/output `
       confluencesynkmd `
-      --mode Download `
+      download `
       --path /workspace/output `
       --conf-space IHR_SPACE_KEY `
       --conf-parent-id IHRE_PAGE_ID
@@ -151,7 +151,7 @@ Das Docker-Image enthält .NET, Node.js und mermaid-cli — eine konsistente, po
       -e CONFLUENCE__APITOKEN ^
       -v %cd%/docs:/workspace/docs:ro ^
       confluencesynkmd ^
-      --mode Upload ^
+      upload ^
       --path /workspace/docs ^
       --conf-space IHR_SPACE_KEY ^
       --conf-parent-id IHRE_PAGE_ID
@@ -164,7 +164,7 @@ Das Docker-Image enthält .NET, Node.js und mermaid-cli — eine konsistente, po
       -e CONFLUENCE__APITOKEN ^
       -v %cd%/output:/workspace/output ^
       confluencesynkmd ^
-      --mode Download ^
+      download ^
       --path /workspace/output ^
       --conf-space IHR_SPACE_KEY ^
       --conf-parent-id IHRE_PAGE_ID
@@ -177,7 +177,7 @@ Das Docker-Image enthält .NET, Node.js und mermaid-cli — eine konsistente, po
       -e CONFLUENCE__APITOKEN ^
       -v %cd%/docs:/workspace/docs:ro ^
       confluencesynkmd ^
-      --mode Upload ^
+      upload ^
       --path /workspace/docs ^
       --conf-space IHR_SPACE_KEY ^
       --conf-parent-id IHRE_PAGE_ID
@@ -190,7 +190,7 @@ Das Docker-Image enthält .NET, Node.js und mermaid-cli — eine konsistente, po
       -e CONFLUENCE__APITOKEN ^
       -v %cd%/output:/workspace/output ^
       confluencesynkmd ^
-      --mode Download ^
+      download ^
       --path /workspace/output ^
       --conf-space IHR_SPACE_KEY ^
       --conf-parent-id IHRE_PAGE_ID
@@ -253,7 +253,7 @@ Das Docker-Image enthält .NET, Node.js und mermaid-cli — eine konsistente, po
                 -e CONFLUENCE__APITOKEN \
                 -v "$PWD/docs:/workspace/docs:ro" \
                 confluencesynkmd \
-                --mode Upload \
+                upload \
                 --path /workspace/docs \
                 --conf-space "${{ vars.CONFLUENCE_SPACE }}" \
                 --conf-parent-id "${{ vars.CONFLUENCE_PARENT_ID }}"
@@ -282,7 +282,7 @@ Das Docker-Image enthält .NET, Node.js und mermaid-cli — eine konsistente, po
             -e CONFLUENCE__APITOKEN \
             -v "$CI_PROJECT_DIR/docs:/workspace/docs:ro" \
             confluencesynkmd \
-            --mode Upload \
+            upload \
             --path /workspace/docs \
             --conf-space "$CONFLUENCE_SPACE" \
             --conf-parent-id "$CONFLUENCE_PARENT_ID"

--- a/docs/de/quickstart.md
+++ b/docs/de/quickstart.md
@@ -152,7 +152,7 @@ Laden Sie einen Ordner mit Markdown-Dateien nach Confluence hoch:
 
     ```bash
     dotnet run --project src/ConfluenceSynkMD -- \
-      --mode Upload \
+      upload \
       --path ./my-docs \
       --conf-space IHR_SPACE_KEY \
       --conf-parent-id IHRE_PAGE_ID
@@ -162,7 +162,7 @@ Laden Sie einen Ordner mit Markdown-Dateien nach Confluence hoch:
 
     ```powershell
     dotnet run --project src/ConfluenceSynkMD -- `
-      --mode Upload `
+      upload `
       --path ./my-docs `
       --conf-space IHR_SPACE_KEY `
       --conf-parent-id IHRE_PAGE_ID
@@ -172,7 +172,7 @@ Laden Sie einen Ordner mit Markdown-Dateien nach Confluence hoch:
 
     ```cmd
     dotnet run --project src/ConfluenceSynkMD -- ^
-      --mode Upload ^
+      upload ^
       --path .\my-docs ^
       --conf-space IHR_SPACE_KEY ^
       --conf-parent-id IHRE_PAGE_ID
@@ -190,7 +190,7 @@ Laden Sie einen Ordner mit Markdown-Dateien nach Confluence hoch:
       -e CONFLUENCE__APITOKEN=ihr-token \
       -v ${PWD}:/workspace \
       confluencesynkmd \
-      --mode Upload \
+      upload \
       --path /workspace/my-docs \
       --conf-space IHR_SPACE_KEY \
       --conf-parent-id IHRE_PAGE_ID
@@ -211,7 +211,7 @@ Laden Sie einen Ordner mit Markdown-Dateien nach Confluence hoch:
       -e CONFLUENCE__APITOKEN=ihr-token `
       -v ${PWD}:/workspace `
       confluencesynkmd `
-      --mode Upload `
+      upload `
       --path /workspace/my-docs `
       --conf-space IHR_SPACE_KEY `
       --conf-parent-id IHRE_PAGE_ID
@@ -232,7 +232,7 @@ Laden Sie einen Ordner mit Markdown-Dateien nach Confluence hoch:
       -e CONFLUENCE__APITOKEN=ihr-token ^
       -v %cd%:/workspace ^
       confluencesynkmd ^
-      --mode Upload ^
+      upload ^
       --path /workspace/my-docs ^
       --conf-space IHR_SPACE_KEY ^
       --conf-parent-id IHRE_PAGE_ID
@@ -271,7 +271,7 @@ Laden Sie Confluence-Seiten als Markdown herunter:
 
     ```bash
     dotnet run --project src/ConfluenceSynkMD -- \
-      --mode Download \
+      download \
       --path ./output \
       --conf-space IHR_SPACE_KEY \
       --conf-parent-id IHRE_PAGE_ID
@@ -281,7 +281,7 @@ Laden Sie Confluence-Seiten als Markdown herunter:
 
     ```powershell
     dotnet run --project src/ConfluenceSynkMD -- `
-      --mode Download `
+      download `
       --path ./output `
       --conf-space IHR_SPACE_KEY `
       --conf-parent-id IHRE_PAGE_ID
@@ -291,7 +291,7 @@ Laden Sie Confluence-Seiten als Markdown herunter:
 
     ```cmd
     dotnet run --project src/ConfluenceSynkMD -- ^
-      --mode Download ^
+      download ^
       --path .\output ^
       --conf-space IHR_SPACE_KEY ^
       --conf-parent-id IHRE_PAGE_ID
@@ -309,7 +309,7 @@ Laden Sie Confluence-Seiten als Markdown herunter:
       -e CONFLUENCE__APITOKEN=ihr-token \
       -v ${PWD}:/workspace \
       confluencesynkmd \
-      --mode Download \
+      download \
       --path /workspace/output \
       --conf-space IHR_SPACE_KEY \
       --conf-parent-id IHRE_PAGE_ID
@@ -330,7 +330,7 @@ Laden Sie Confluence-Seiten als Markdown herunter:
       -e CONFLUENCE__APITOKEN=ihr-token `
       -v ${PWD}:/workspace `
       confluencesynkmd `
-      --mode Download `
+      download `
       --path /workspace/output `
       --conf-space IHR_SPACE_KEY `
       --conf-parent-id IHRE_PAGE_ID
@@ -351,7 +351,7 @@ Laden Sie Confluence-Seiten als Markdown herunter:
       -e CONFLUENCE__APITOKEN=ihr-token ^
       -v %cd%:/workspace ^
       confluencesynkmd ^
-      --mode Download ^
+      download ^
       --path /workspace/output ^
       --conf-space IHR_SPACE_KEY ^
       --conf-parent-id IHRE_PAGE_ID

--- a/docs/en/admin/docker.md
+++ b/docs/en/admin/docker.md
@@ -44,7 +44,7 @@ The Dockerfile uses a **multi-stage build**:
       -e CONFLUENCE__APITOKEN \
       -v $(pwd)/docs:/workspace/docs:ro \
       confluencesynkmd \
-      --mode Upload \
+      upload \
       --path /workspace/docs \
       --conf-space YOUR_SPACE_KEY \
       --conf-parent-id YOUR_PAGE_ID
@@ -57,7 +57,7 @@ The Dockerfile uses a **multi-stage build**:
       -e CONFLUENCE__APITOKEN \
       -v $(pwd)/output:/workspace/output \
       confluencesynkmd \
-      --mode Download \
+      download \
       --path /workspace/output \
       --conf-space YOUR_SPACE_KEY \
       --conf-parent-id YOUR_PAGE_ID
@@ -70,7 +70,7 @@ The Dockerfile uses a **multi-stage build**:
       -e CONFLUENCE__APITOKEN \
       -v $(pwd)/docs:/workspace/docs:ro \
       confluencesynkmd \
-      --mode Upload \
+      upload \
       --path /workspace/docs \
       --conf-space YOUR_SPACE_KEY \
       --conf-parent-id YOUR_PAGE_ID
@@ -83,7 +83,7 @@ The Dockerfile uses a **multi-stage build**:
       -e CONFLUENCE__APITOKEN \
       -v $(pwd)/output:/workspace/output \
       confluencesynkmd \
-      --mode Download \
+      download \
       --path /workspace/output \
       --conf-space YOUR_SPACE_KEY \
       --conf-parent-id YOUR_PAGE_ID
@@ -100,7 +100,7 @@ The Dockerfile uses a **multi-stage build**:
       -e CONFLUENCE__APITOKEN `
       -v ${PWD}/docs:/workspace/docs:ro `
       confluencesynkmd `
-      --mode Upload `
+      upload `
       --path /workspace/docs `
       --conf-space YOUR_SPACE_KEY `
       --conf-parent-id YOUR_PAGE_ID
@@ -113,7 +113,7 @@ The Dockerfile uses a **multi-stage build**:
       -e CONFLUENCE__APITOKEN `
       -v ${PWD}/output:/workspace/output `
       confluencesynkmd `
-      --mode Download `
+      download `
       --path /workspace/output `
       --conf-space YOUR_SPACE_KEY `
       --conf-parent-id YOUR_PAGE_ID
@@ -126,7 +126,7 @@ The Dockerfile uses a **multi-stage build**:
       -e CONFLUENCE__APITOKEN `
       -v ${PWD}/docs:/workspace/docs:ro `
       confluencesynkmd `
-      --mode Upload `
+      upload `
       --path /workspace/docs `
       --conf-space YOUR_SPACE_KEY `
       --conf-parent-id YOUR_PAGE_ID
@@ -139,7 +139,7 @@ The Dockerfile uses a **multi-stage build**:
       -e CONFLUENCE__APITOKEN `
       -v ${PWD}/output:/workspace/output `
       confluencesynkmd `
-      --mode Download `
+      download `
       --path /workspace/output `
       --conf-space YOUR_SPACE_KEY `
       --conf-parent-id YOUR_PAGE_ID
@@ -156,7 +156,7 @@ The Dockerfile uses a **multi-stage build**:
       -e CONFLUENCE__APITOKEN ^
       -v %cd%/docs:/workspace/docs:ro ^
       confluencesynkmd ^
-      --mode Upload ^
+      upload ^
       --path /workspace/docs ^
       --conf-space YOUR_SPACE_KEY ^
       --conf-parent-id YOUR_PAGE_ID
@@ -169,7 +169,7 @@ The Dockerfile uses a **multi-stage build**:
       -e CONFLUENCE__APITOKEN ^
       -v %cd%/output:/workspace/output ^
       confluencesynkmd ^
-      --mode Download ^
+      download ^
       --path /workspace/output ^
       --conf-space YOUR_SPACE_KEY ^
       --conf-parent-id YOUR_PAGE_ID
@@ -182,7 +182,7 @@ The Dockerfile uses a **multi-stage build**:
       -e CONFLUENCE__APITOKEN ^
       -v %cd%/docs:/workspace/docs:ro ^
       confluencesynkmd ^
-      --mode Upload ^
+      upload ^
       --path /workspace/docs ^
       --conf-space YOUR_SPACE_KEY ^
       --conf-parent-id YOUR_PAGE_ID
@@ -195,7 +195,7 @@ The Dockerfile uses a **multi-stage build**:
       -e CONFLUENCE__APITOKEN ^
       -v %cd%/output:/workspace/output ^
       confluencesynkmd ^
-      --mode Download ^
+      download ^
       --path /workspace/output ^
       --conf-space YOUR_SPACE_KEY ^
       --conf-parent-id YOUR_PAGE_ID
@@ -258,7 +258,7 @@ The Dockerfile uses a **multi-stage build**:
                 -e CONFLUENCE__APITOKEN \
                 -v "$PWD/docs:/workspace/docs:ro" \
                 confluencesynkmd \
-                --mode Upload \
+                upload \
                 --path /workspace/docs \
                 --conf-space "${{ vars.CONFLUENCE_SPACE }}" \
                 --conf-parent-id "${{ vars.CONFLUENCE_PARENT_ID }}"
@@ -287,7 +287,7 @@ The Dockerfile uses a **multi-stage build**:
             -e CONFLUENCE__APITOKEN \
             -v "$CI_PROJECT_DIR/docs:/workspace/docs:ro" \
             confluencesynkmd \
-            --mode Upload \
+            upload \
             --path /workspace/docs \
             --conf-space "$CONFLUENCE_SPACE" \
             --conf-parent-id "$CONFLUENCE_PARENT_ID"

--- a/docs/en/quickstart.md
+++ b/docs/en/quickstart.md
@@ -152,7 +152,7 @@ Upload a folder of Markdown files to Confluence:
 
     ```bash
     dotnet run --project src/ConfluenceSynkMD -- \
-      --mode Upload \
+      upload \
       --path ./my-docs \
       --conf-space YOUR_SPACE_KEY \
       --conf-parent-id YOUR_PAGE_ID
@@ -162,7 +162,7 @@ Upload a folder of Markdown files to Confluence:
 
     ```powershell
     dotnet run --project src/ConfluenceSynkMD -- `
-      --mode Upload `
+      upload `
       --path ./my-docs `
       --conf-space YOUR_SPACE_KEY `
       --conf-parent-id YOUR_PAGE_ID
@@ -172,7 +172,7 @@ Upload a folder of Markdown files to Confluence:
 
     ```cmd
     dotnet run --project src/ConfluenceSynkMD -- ^
-      --mode Upload ^
+      upload ^
       --path .\my-docs ^
       --conf-space YOUR_SPACE_KEY ^
       --conf-parent-id YOUR_PAGE_ID
@@ -190,7 +190,7 @@ Upload a folder of Markdown files to Confluence:
       -e CONFLUENCE__APITOKEN=your-token \
       -v ${PWD}:/workspace \
       confluencesynkmd \
-      --mode Upload \
+      upload \
       --path /workspace/my-docs \
       --conf-space YOUR_SPACE_KEY \
       --conf-parent-id YOUR_PAGE_ID
@@ -211,7 +211,7 @@ Upload a folder of Markdown files to Confluence:
       -e CONFLUENCE__APITOKEN=your-token `
       -v ${PWD}:/workspace `
       confluencesynkmd `
-      --mode Upload `
+      upload `
       --path /workspace/my-docs `
       --conf-space YOUR_SPACE_KEY `
       --conf-parent-id YOUR_PAGE_ID
@@ -232,7 +232,7 @@ Upload a folder of Markdown files to Confluence:
       -e CONFLUENCE__APITOKEN=your-token ^
       -v %cd%:/workspace ^
       confluencesynkmd ^
-      --mode Upload ^
+      upload ^
       --path /workspace/my-docs ^
       --conf-space YOUR_SPACE_KEY ^
       --conf-parent-id YOUR_PAGE_ID
@@ -271,7 +271,7 @@ Download Confluence pages back to Markdown:
 
     ```bash
     dotnet run --project src/ConfluenceSynkMD -- \
-      --mode Download \
+      download \
       --path ./output \
       --conf-space YOUR_SPACE_KEY \
       --conf-parent-id YOUR_PAGE_ID
@@ -281,7 +281,7 @@ Download Confluence pages back to Markdown:
 
     ```powershell
     dotnet run --project src/ConfluenceSynkMD -- `
-      --mode Download `
+      download `
       --path ./output `
       --conf-space YOUR_SPACE_KEY `
       --conf-parent-id YOUR_PAGE_ID
@@ -291,7 +291,7 @@ Download Confluence pages back to Markdown:
 
     ```cmd
     dotnet run --project src/ConfluenceSynkMD -- ^
-      --mode Download ^
+      download ^
       --path .\output ^
       --conf-space YOUR_SPACE_KEY ^
       --conf-parent-id YOUR_PAGE_ID
@@ -309,7 +309,7 @@ Download Confluence pages back to Markdown:
       -e CONFLUENCE__APITOKEN=your-token \
       -v ${PWD}:/workspace \
       confluencesynkmd \
-      --mode Download \
+      download \
       --path /workspace/output \
       --conf-space YOUR_SPACE_KEY \
       --conf-parent-id YOUR_PAGE_ID
@@ -330,7 +330,7 @@ Download Confluence pages back to Markdown:
       -e CONFLUENCE__APITOKEN=your-token `
       -v ${PWD}:/workspace `
       confluencesynkmd `
-      --mode Download `
+      download `
       --path /workspace/output `
       --conf-space YOUR_SPACE_KEY `
       --conf-parent-id YOUR_PAGE_ID
@@ -351,7 +351,7 @@ Download Confluence pages back to Markdown:
       -e CONFLUENCE__APITOKEN=your-token ^
       -v %cd%:/workspace ^
       confluencesynkmd ^
-      --mode Download ^
+      download ^
       --path /workspace/output ^
       --conf-space YOUR_SPACE_KEY ^
       --conf-parent-id YOUR_PAGE_ID

--- a/src/ConfluenceSynkMD/Configuration/CliMigrationCheck.cs
+++ b/src/ConfluenceSynkMD/Configuration/CliMigrationCheck.cs
@@ -5,15 +5,22 @@ namespace ConfluenceSynkMD.Configuration;
 /// and removed the legacy `--mode` flag and `--local` toggle. This helper
 /// detects users running the old syntax and produces a friendly migration
 /// hint instead of System.CommandLine's bare "Unrecognized option" error.
+///
+/// Forms detected:
+///   <c>--mode Upload</c>          (space-separated)
+///   <c>--mode=Upload</c>          (equals form)
+///   <c>--mode:Upload</c>          (colon form, accepted by System.CommandLine)
+///   <c>--local</c>                (the old standalone flag)
+/// All matching is case-insensitive.
 /// </summary>
 public static class CliMigrationCheck
 {
     /// <summary>
-    /// Inspects raw process args for a legacy `--mode &lt;value&gt;` flag.
+    /// Inspects raw process args for legacy CLI flags removed in v0.1.0.
     /// </summary>
     /// <param name="args">The args passed to the entry point.</param>
     /// <returns>
-    /// A migration message + suggested subcommand name when `--mode` is
+    /// A migration message + suggested subcommand name when a legacy flag is
     /// present in <paramref name="args"/>; otherwise <c>null</c>.
     /// </returns>
     public static MigrationHint? CheckLegacyModeFlag(string[] args)
@@ -22,21 +29,75 @@ public static class CliMigrationCheck
 
         for (var i = 0; i < args.Length; i++)
         {
-            if (!string.Equals(args[i], "--mode", StringComparison.OrdinalIgnoreCase))
-                continue;
+            var arg = args[i];
+            if (string.IsNullOrEmpty(arg)) continue;
 
-            var modeValue = (i + 1 < args.Length) ? args[i + 1] : "<missing>";
-            var subcommand = MapModeValueToSubcommand(modeValue);
+            // --mode <Value> (space-separated form)
+            if (string.Equals(arg, "--mode", StringComparison.OrdinalIgnoreCase))
+            {
+                var modeValue = (i + 1 < args.Length) ? args[i + 1] : "<missing>";
+                return BuildModeHint(modeValue);
+            }
 
-            var message =
-                $"`--mode` was removed in v0.1.0. Use the `{subcommand}` subcommand instead:" + Environment.NewLine
-                + $"  confluencesynkmd {subcommand} <other args...>" + Environment.NewLine
-                + "See the v0.1.0 CHANGELOG for the full migration table.";
+            // --mode=Value or --mode:Value (equals/colon forms)
+            if (TryExtractInlineValue(arg, "--mode", out var inlineModeValue))
+            {
+                return BuildModeHint(inlineModeValue);
+            }
 
-            return new MigrationHint(subcommand, message);
+            // --local (standalone flag, also removed in v0.1.0)
+            if (string.Equals(arg, "--local", StringComparison.OrdinalIgnoreCase))
+            {
+                return BuildLocalHint();
+            }
         }
 
         return null;
+    }
+
+    private static MigrationHint BuildModeHint(string modeValue)
+    {
+        var subcommand = MapModeValueToSubcommand(modeValue);
+        var message =
+            $"`--mode` was removed in v0.1.0. Use the `{subcommand}` subcommand instead:" + Environment.NewLine
+            + $"  confluencesynkmd {subcommand} <other args...>" + Environment.NewLine
+            + Environment.NewLine
+            + "Migration table:" + Environment.NewLine
+            + "  --mode Upload          ->  upload" + Environment.NewLine
+            + "  --mode Download        ->  download" + Environment.NewLine
+            + "  --mode LocalExport     ->  local" + Environment.NewLine
+            + "  --mode Upload --local  ->  local" + Environment.NewLine;
+        return new MigrationHint(subcommand, message);
+    }
+
+    private static MigrationHint BuildLocalHint()
+    {
+        var message =
+            "`--local` was removed in v0.1.0. Use the `local` subcommand instead:" + Environment.NewLine
+            + "  confluencesynkmd local <other args...>" + Environment.NewLine
+            + Environment.NewLine
+            + "Migration table:" + Environment.NewLine
+            + "  --mode Upload          ->  upload" + Environment.NewLine
+            + "  --mode Download        ->  download" + Environment.NewLine
+            + "  --mode LocalExport     ->  local" + Environment.NewLine
+            + "  --mode Upload --local  ->  local" + Environment.NewLine;
+        return new MigrationHint("local", message);
+    }
+
+    private static bool TryExtractInlineValue(string arg, string flagPrefix, out string value)
+    {
+        // Match `--mode=...` and `--mode:...` (System.CommandLine accepts both).
+        if (arg.Length > flagPrefix.Length
+            && arg.StartsWith(flagPrefix, StringComparison.OrdinalIgnoreCase)
+            && (arg[flagPrefix.Length] == '=' || arg[flagPrefix.Length] == ':'))
+        {
+            value = arg[(flagPrefix.Length + 1)..];
+            if (string.IsNullOrEmpty(value)) value = "<missing>";
+            return true;
+        }
+
+        value = string.Empty;
+        return false;
     }
 
     private static string MapModeValueToSubcommand(string modeValue) =>

--- a/src/ConfluenceSynkMD/Services/DrawioRenderer.cs
+++ b/src/ConfluenceSynkMD/Services/DrawioRenderer.cs
@@ -36,26 +36,28 @@ public sealed class DrawioRenderer : IDiagramRenderer
         {
             await File.WriteAllTextAsync(inputFile, source, ct);
 
-            // Try drawio CLI (drawio-export or drawio desktop in headless mode)
-            var drawioCmd = FindDrawioCommand();
-            if (drawioCmd is null)
+            // Resolve the drawio invocation — supports DRAWIO_CMD with extra args
+            // (e.g. "drawio --no-sandbox --disable-gpu") via the shared resolver.
+            var resolved = ResolveDrawioCommand();
+            if (resolved is null)
             {
                 throw new InvalidOperationException(
                     "Draw.io CLI not found. Install 'drawio-desktop' or set DRAWIO_CMD environment variable.");
             }
 
+            var perCallArgs = $"--export --format {outputFormat} --output \"{outputFile}\" \"{inputFile}\"";
+
             var psi = new ProcessStartInfo
             {
-                FileName = drawioCmd,
-                Arguments = $"--export --format {outputFormat} --output \"{outputFile}\" \"{inputFile}\"",
+                FileName = resolved.Value.FileName,
+                Arguments = RendererCommandResolver.CombineArgs(resolved.Value.ArgsPrefix, perCallArgs),
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
                 UseShellExecute = false,
                 CreateNoWindow = true,
             };
 
-            using var process = Process.Start(psi)
-                ?? throw new InvalidOperationException("Failed to start Draw.io process.");
+            using var process = StartDrawioProcess(psi);
 
             await process.WaitForExitAsync(ct);
 
@@ -86,14 +88,38 @@ public sealed class DrawioRenderer : IDiagramRenderer
         return await RenderAsync(xml, outputFormat, ct);
     }
 
-    private static string? FindDrawioCommand()
+    private static Process StartDrawioProcess(ProcessStartInfo psi)
     {
-        // Check environment variable first
-        var envCmd = Environment.GetEnvironmentVariable("DRAWIO_CMD");
-        if (!string.IsNullOrEmpty(envCmd) && File.Exists(envCmd))
-            return envCmd;
+        try
+        {
+            return Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start Draw.io process.");
+        }
+        catch (System.ComponentModel.Win32Exception ex)
+        {
+            // Process.Start throws Win32Exception when the binary is missing or
+            // unreachable (e.g. DRAWIO_CMD points at a path that does not exist
+            // on this machine, or PATH is empty). Translate to the renderer's
+            // documented "Draw.io CLI not found" contract so callers get the
+            // same error shape regardless of OS-level failure mode.
+            throw new InvalidOperationException(
+                $"Draw.io CLI not found at '{psi.FileName}'. Install 'drawio-desktop' or set DRAWIO_CMD to a valid binary.",
+                ex);
+        }
+    }
 
-        // Common paths
+    private static (string FileName, string ArgsPrefix)? ResolveDrawioCommand()
+    {
+        // Honor DRAWIO_CMD first. Accepts either a bare binary name
+        // ("drawio") or a multi-token invocation
+        // ("drawio --no-sandbox --disable-gpu"), parsed via the shared resolver.
+        var envCmd = Environment.GetEnvironmentVariable("DRAWIO_CMD");
+        if (!string.IsNullOrWhiteSpace(envCmd))
+        {
+            return RendererCommandResolver.Parse(envCmd);
+        }
+
+        // Fall back to common installation paths (single-binary, no extra args).
         var candidates = new[]
         {
             "drawio",
@@ -119,12 +145,12 @@ public sealed class DrawioRenderer : IDiagramRenderer
                 if (p is not null)
                 {
                     p.Kill();
-                    return candidate;
+                    return (candidate, string.Empty);
                 }
             }
             catch
             {
-                // Not found, try next
+                // Not found, try next.
             }
         }
 

--- a/src/ConfluenceSynkMD/Services/LatexRenderer.cs
+++ b/src/ConfluenceSynkMD/Services/LatexRenderer.cs
@@ -5,8 +5,17 @@ namespace ConfluenceSynkMD.Services;
 
 /// <summary>
 /// Renders LaTeX formulas to PNG images.
-/// Can use either a LaTeX distribution (pdflatex + convert) or the
-/// Confluence math-inline/math-display macro as fallback.
+/// Pipeline: <c>pdflatex</c> compiles a wrapper document to PDF, then
+/// <c>gs</c> (Ghostscript) rasterizes the PDF to PNG. ImageMagick is no
+/// longer required — Ghostscript handles PDF rasterization natively, which
+/// drops a dependency from the runtime image and removes the policy.xml
+/// workaround for ImageMagick's PDF-read default-deny policy.
+///
+/// Both binaries are resolved from PATH by default; override either via
+/// the <c>LATEX_PDFLATEX_CMD</c> and <c>LATEX_GHOSTSCRIPT_CMD</c> environment
+/// variables. Each accepts either a bare binary name ("pdflatex") or a
+/// multi-token invocation ("xelatex --shell-escape") parsed via
+/// <see cref="RendererCommandResolver"/>.
 /// </summary>
 public sealed class LatexRenderer : ILatexRenderer
 {
@@ -39,21 +48,32 @@ public sealed class LatexRenderer : ILatexRenderer
             var texContent = WrapInDocument(latexSource);
             await File.WriteAllTextAsync(texFile, texContent, ct);
 
-            // Step 1: Compile LaTeX to PDF
-            await RunProcessAsync("pdflatex",
-                $"-interaction=nonstopmode -output-directory=\"{tempDir}\" \"{texFile}\"", ct);
+            // Step 1: Compile LaTeX to PDF.
+            var pdflatex = ResolvePdflatexCommand();
+            var pdflatexCallArgs = $"-interaction=nonstopmode -output-directory=\"{tempDir}\" \"{texFile}\"";
+            await RunProcessAsync(
+                pdflatex.FileName,
+                RendererCommandResolver.CombineArgs(pdflatex.ArgsPrefix, pdflatexCallArgs),
+                ct);
 
-            // Step 2: Convert PDF to PNG using ImageMagick or Ghostscript
+            // Step 2: Rasterize PDF to PNG via Ghostscript directly.
+            // -sDEVICE=pngalpha keeps formula transparency; -r300 matches the
+            // density the previous ImageMagick pipeline used. Ghostscript reads
+            // PDFs natively, so no ImageMagick policy.xml workaround is needed.
             if (File.Exists(pdfFile))
             {
-                await RunProcessAsync("convert",
-                    $"-density 300 \"{pdfFile}\" -trim -quality 100 \"{pngFile}\"", ct);
+                var gs = ResolveGhostscriptCommand();
+                var gsCallArgs = $"-dNOPAUSE -dBATCH -dQUIET -sDEVICE=pngalpha -r300 -sOutputFile=\"{pngFile}\" \"{pdfFile}\"";
+                await RunProcessAsync(
+                    gs.FileName,
+                    RendererCommandResolver.CombineArgs(gs.ArgsPrefix, gsCallArgs),
+                    ct);
             }
 
             if (!File.Exists(pngFile))
             {
                 throw new InvalidOperationException(
-                    "LaTeX rendering failed. Ensure pdflatex and ImageMagick are installed.");
+                    "LaTeX rendering failed. Ensure pdflatex and ghostscript are installed.");
             }
 
             var imageBytes = await File.ReadAllBytesAsync(pngFile, ct);
@@ -97,6 +117,22 @@ public sealed class LatexRenderer : ILatexRenderer
 \begin{document}
 $" + formula + @"$
 \end{document}";
+    }
+
+    private static (string FileName, string ArgsPrefix) ResolvePdflatexCommand()
+    {
+        var envCmd = Environment.GetEnvironmentVariable("LATEX_PDFLATEX_CMD");
+        return !string.IsNullOrWhiteSpace(envCmd)
+            ? RendererCommandResolver.Parse(envCmd)
+            : ("pdflatex", string.Empty);
+    }
+
+    private static (string FileName, string ArgsPrefix) ResolveGhostscriptCommand()
+    {
+        var envCmd = Environment.GetEnvironmentVariable("LATEX_GHOSTSCRIPT_CMD");
+        return !string.IsNullOrWhiteSpace(envCmd)
+            ? RendererCommandResolver.Parse(envCmd)
+            : ("gs", string.Empty);
     }
 
     private static async Task RunProcessAsync(string command, string arguments, CancellationToken ct)

--- a/src/ConfluenceSynkMD/Services/PlantUmlRenderer.cs
+++ b/src/ConfluenceSynkMD/Services/PlantUmlRenderer.cs
@@ -74,23 +74,26 @@ public sealed class PlantUmlRenderer : IDiagramRenderer
     private static (string Command, string Arguments) BuildCommand(string inputFile, string outputFormat)
     {
         var formatArg = outputFormat.Equals("svg", StringComparison.OrdinalIgnoreCase) ? "-tsvg" : "-tpng";
+        var perCallArgs = $"{formatArg} \"{inputFile}\"";
 
-        // Check PLANTUML_CMD environment variable (direct command)
+        // PLANTUML_CMD: bare binary name OR multi-token invocation
+        // (e.g. "java -jar /opt/plantuml.jar"). Parsed via the shared resolver.
         var cmd = Environment.GetEnvironmentVariable("PLANTUML_CMD");
-        if (!string.IsNullOrEmpty(cmd))
+        if (!string.IsNullOrWhiteSpace(cmd))
         {
-            return (cmd, $"{formatArg} \"{inputFile}\"");
+            var (fileName, argsPrefix) = RendererCommandResolver.Parse(cmd);
+            return (fileName, RendererCommandResolver.CombineArgs(argsPrefix, perCallArgs));
         }
 
-        // Check PLANTUML_JAR environment variable (java -jar ...)
+        // PLANTUML_JAR: convenience for the common "java -jar ..." pattern.
         var jar = Environment.GetEnvironmentVariable("PLANTUML_JAR");
         if (!string.IsNullOrEmpty(jar) && File.Exists(jar))
         {
-            return ("java", $"-jar \"{jar}\" {formatArg} \"{inputFile}\"");
+            return ("java", $"-jar \"{jar}\" {perCallArgs}");
         }
 
-        // Default: try plantuml as a command
-        return ("plantuml", $"{formatArg} \"{inputFile}\"");
+        // Default: try plantuml as a single-token command on PATH.
+        return ("plantuml", perCallArgs);
     }
 
     private static void TryDeleteFile(string path)

--- a/src/ConfluenceSynkMD/Services/RendererCommandResolver.cs
+++ b/src/ConfluenceSynkMD/Services/RendererCommandResolver.cs
@@ -1,0 +1,93 @@
+using System.Text;
+
+namespace ConfluenceSynkMD.Services;
+
+/// <summary>
+/// Parses renderer command env vars (DRAWIO_CMD, PLANTUML_CMD, LATEX_PDFLATEX_CMD,
+/// LATEX_GHOSTSCRIPT_CMD) as shell-style "command + args" strings.
+///
+/// The original renderers passed the env var verbatim into
+/// <see cref="System.Diagnostics.ProcessStartInfo.FileName"/>, which broke
+/// multi-token values such as
+/// <c>DRAWIO_CMD="drawio --no-sandbox --disable-gpu"</c> — Process.Start
+/// looks for a literal file named <c>"drawio --no-sandbox --disable-gpu"</c>
+/// and fails. This helper splits the value into a (FileName, ArgsPrefix) pair
+/// so callers can spawn the binary and prepend the env-supplied flags before
+/// their per-call arguments.
+/// </summary>
+public static class RendererCommandResolver
+{
+    /// <summary>
+    /// Tokenizes <paramref name="envValue"/> with shell-like quoting rules
+    /// (double quotes group whitespace into a single token; backslash and
+    /// single-quote handling are intentionally NOT supported — env vars are
+    /// project config, not arbitrary shell input).
+    /// </summary>
+    /// <returns>
+    /// A pair where <c>FileName</c> is the first token (the executable to
+    /// spawn) and <c>ArgsPrefix</c> is the remaining tokens joined by a single
+    /// space (or empty when the env value is a single bare command).
+    /// Throws <see cref="ArgumentException"/> when the value is empty or
+    /// whitespace-only.
+    /// </returns>
+    public static (string FileName, string ArgsPrefix) Parse(string envValue)
+    {
+        if (string.IsNullOrWhiteSpace(envValue))
+            throw new ArgumentException("Renderer command env value is empty.", nameof(envValue));
+
+        var tokens = Tokenize(envValue);
+        if (tokens.Count == 0)
+            throw new ArgumentException("Renderer command env value contains no tokens.", nameof(envValue));
+
+        var fileName = tokens[0];
+        var argsPrefix = tokens.Count > 1
+            ? string.Join(' ', tokens.Skip(1))
+            : string.Empty;
+
+        return (fileName, argsPrefix);
+    }
+
+    /// <summary>
+    /// Joins an env-supplied argument prefix with a per-call argument suffix,
+    /// preserving spacing semantics. Either side may be empty.
+    /// </summary>
+    public static string CombineArgs(string envArgsPrefix, string callArgs)
+    {
+        if (string.IsNullOrEmpty(envArgsPrefix)) return callArgs;
+        if (string.IsNullOrEmpty(callArgs)) return envArgsPrefix;
+        return $"{envArgsPrefix} {callArgs}";
+    }
+
+    private static List<string> Tokenize(string input)
+    {
+        var tokens = new List<string>();
+        var current = new StringBuilder();
+        var inQuote = false;
+
+        foreach (var c in input)
+        {
+            if (c == '"')
+            {
+                inQuote = !inQuote;
+                continue;
+            }
+
+            if (char.IsWhiteSpace(c) && !inQuote)
+            {
+                if (current.Length > 0)
+                {
+                    tokens.Add(current.ToString());
+                    current.Clear();
+                }
+                continue;
+            }
+
+            current.Append(c);
+        }
+
+        if (current.Length > 0)
+            tokens.Add(current.ToString());
+
+        return tokens;
+    }
+}

--- a/tests/ConfluenceSynkMD.Tests/Configuration/CliMigrationCheckTests.cs
+++ b/tests/ConfluenceSynkMD.Tests/Configuration/CliMigrationCheckTests.cs
@@ -90,7 +90,23 @@ public class CliMigrationCheckTests
 
         result.Should().NotBeNull();
         result!.Message.Should().Contain("confluencesynkmd upload <other args...>");
-        result.Message.Should().Contain("CHANGELOG");
+    }
+
+    [Fact]
+    public void Migration_message_inlines_the_migration_table_instead_of_pointing_at_CHANGELOG()
+    {
+        var result = CliMigrationCheck.CheckLegacyModeFlag(
+            new[] { "--mode", "Upload" });
+
+        result.Should().NotBeNull();
+        // The earlier draft pointed at a CHANGELOG that didn't exist. The fix
+        // is to inline the migration table directly in the error message.
+        result!.Message.Should().NotContain("CHANGELOG");
+        result.Message.Should().Contain("Migration table:");
+        result.Message.Should().Contain("--mode Upload          ->  upload");
+        result.Message.Should().Contain("--mode Download        ->  download");
+        result.Message.Should().Contain("--mode LocalExport     ->  local");
+        result.Message.Should().Contain("--mode Upload --local  ->  local");
     }
 
     [Fact]
@@ -101,5 +117,77 @@ public class CliMigrationCheckTests
 
         result.Should().NotBeNull();
         result!.SuggestedSubcommand.Should().Be("upload");
+    }
+
+    [Theory]
+    [InlineData("--mode=Upload", "upload")]
+    [InlineData("--mode=Download", "download")]
+    [InlineData("--mode=LocalExport", "local")]
+    [InlineData("--MODE=Upload", "upload")]
+    [InlineData("--Mode=download", "download")]
+    public void Detects_equals_form_of_mode_flag(string equalsArg, string expectedSubcommand)
+    {
+        var result = CliMigrationCheck.CheckLegacyModeFlag(
+            new[] { equalsArg, "--path", "./docs", "--conf-space", "DEV" });
+
+        result.Should().NotBeNull();
+        result!.SuggestedSubcommand.Should().Be(expectedSubcommand);
+    }
+
+    [Theory]
+    [InlineData("--mode:Upload", "upload")]
+    [InlineData("--mode:Download", "download")]
+    [InlineData("--mode:LocalExport", "local")]
+    public void Detects_colon_form_of_mode_flag(string colonArg, string expectedSubcommand)
+    {
+        var result = CliMigrationCheck.CheckLegacyModeFlag(
+            new[] { colonArg, "--path", "./docs", "--conf-space", "DEV" });
+
+        result.Should().NotBeNull();
+        result!.SuggestedSubcommand.Should().Be(expectedSubcommand);
+    }
+
+    [Fact]
+    public void Detects_legacy_local_flag_and_suggests_local_subcommand()
+    {
+        var result = CliMigrationCheck.CheckLegacyModeFlag(
+            new[] { "upload", "--path", "./docs", "--local", "--conf-space", "DEV" });
+
+        result.Should().NotBeNull();
+        result!.SuggestedSubcommand.Should().Be("local");
+        result.Message.Should().Contain("`--local` was removed in v0.1.0");
+        result.Message.Should().Contain("confluencesynkmd local <other args...>");
+    }
+
+    [Fact]
+    public void Local_flag_match_is_case_insensitive()
+    {
+        var result = CliMigrationCheck.CheckLegacyModeFlag(
+            new[] { "--LOCAL" });
+
+        result.Should().NotBeNull();
+        result!.SuggestedSubcommand.Should().Be("local");
+    }
+
+    [Fact]
+    public void Equals_form_with_empty_value_falls_back_to_placeholder()
+    {
+        // `--mode=` with nothing after the equals.
+        var result = CliMigrationCheck.CheckLegacyModeFlag(
+            new[] { "--mode=" });
+
+        result.Should().NotBeNull();
+        result!.SuggestedSubcommand.Should().Be("<upload|download|local>");
+    }
+
+    [Fact]
+    public void New_subcommand_args_are_not_flagged_as_legacy()
+    {
+        // The new `local` subcommand should NOT trigger a migration hint
+        // even though the word "local" appears in args.
+        var result = CliMigrationCheck.CheckLegacyModeFlag(
+            new[] { "local", "--path", "./docs", "--conf-space", "DEV" });
+
+        result.Should().BeNull();
     }
 }

--- a/tests/ConfluenceSynkMD.Tests/Services/RendererCommandResolverTests.cs
+++ b/tests/ConfluenceSynkMD.Tests/Services/RendererCommandResolverTests.cs
@@ -1,0 +1,115 @@
+using ConfluenceSynkMD.Services;
+using FluentAssertions;
+
+namespace ConfluenceSynkMD.Tests.Services;
+
+/// <summary>
+/// Regression test R2 (renderer cmd-args parsing backward compat): verifies
+/// the shared <see cref="RendererCommandResolver"/> handles every shape the
+/// renderer env vars (DRAWIO_CMD, PLANTUML_CMD, LATEX_PDFLATEX_CMD,
+/// LATEX_GHOSTSCRIPT_CMD) are now expected to support — single-binary names
+/// (the old contract) AND multi-token invocations (the v0.1.0 contract).
+/// </summary>
+public class RendererCommandResolverTests
+{
+    [Fact]
+    public void Single_binary_name_returns_filename_with_empty_args_prefix()
+    {
+        var (fileName, argsPrefix) = RendererCommandResolver.Parse("drawio");
+
+        fileName.Should().Be("drawio");
+        argsPrefix.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Multi_token_string_splits_on_whitespace()
+    {
+        var (fileName, argsPrefix) = RendererCommandResolver.Parse("drawio --no-sandbox --disable-gpu");
+
+        fileName.Should().Be("drawio");
+        argsPrefix.Should().Be("--no-sandbox --disable-gpu");
+    }
+
+    [Fact]
+    public void Java_jar_invocation_parses_into_command_plus_args()
+    {
+        var (fileName, argsPrefix) = RendererCommandResolver.Parse("java -jar /opt/plantuml.jar");
+
+        fileName.Should().Be("java");
+        argsPrefix.Should().Be("-jar /opt/plantuml.jar");
+    }
+
+    [Fact]
+    public void Quoted_arg_with_space_is_kept_as_a_single_token()
+    {
+        var (fileName, argsPrefix) = RendererCommandResolver.Parse("wrapper \"arg with space\" --flag");
+
+        fileName.Should().Be("wrapper");
+        argsPrefix.Should().Be("arg with space --flag");
+    }
+
+    [Fact]
+    public void Quoted_path_with_spaces_is_preserved()
+    {
+        var (fileName, argsPrefix) = RendererCommandResolver.Parse("\"/Applications/draw.io.app/Contents/MacOS/draw.io\" --no-sandbox");
+
+        fileName.Should().Be("/Applications/draw.io.app/Contents/MacOS/draw.io");
+        argsPrefix.Should().Be("--no-sandbox");
+    }
+
+    [Fact]
+    public void Multiple_spaces_between_tokens_collapse()
+    {
+        var (fileName, argsPrefix) = RendererCommandResolver.Parse("drawio    --no-sandbox     --disable-gpu");
+
+        fileName.Should().Be("drawio");
+        argsPrefix.Should().Be("--no-sandbox --disable-gpu");
+    }
+
+    [Fact]
+    public void Tab_and_other_whitespace_split_tokens_too()
+    {
+        var (fileName, argsPrefix) = RendererCommandResolver.Parse("java\t-jar\t/opt/plantuml.jar");
+
+        fileName.Should().Be("java");
+        argsPrefix.Should().Be("-jar /opt/plantuml.jar");
+    }
+
+    [Fact]
+    public void Empty_input_throws()
+    {
+        Action act = () => RendererCommandResolver.Parse(string.Empty);
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void Whitespace_only_input_throws()
+    {
+        Action act = () => RendererCommandResolver.Parse("   ");
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void CombineArgs_returns_call_args_when_prefix_is_empty()
+    {
+        RendererCommandResolver.CombineArgs(string.Empty, "--export --format png").Should().Be("--export --format png");
+    }
+
+    [Fact]
+    public void CombineArgs_returns_prefix_when_call_args_is_empty()
+    {
+        RendererCommandResolver.CombineArgs("--no-sandbox --disable-gpu", string.Empty).Should().Be("--no-sandbox --disable-gpu");
+    }
+
+    [Fact]
+    public void CombineArgs_joins_prefix_and_call_args_with_single_space()
+    {
+        RendererCommandResolver.CombineArgs("--no-sandbox", "--export").Should().Be("--no-sandbox --export");
+    }
+
+    [Fact]
+    public void CombineArgs_handles_both_empty()
+    {
+        RendererCommandResolver.CombineArgs(string.Empty, string.Empty).Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
## Summary

Hot-fix on top of the merged PR #51 + PR #52 series. An independent code review caught **five real issues** that would have shipped a broken v0.1.0 image — two of the four advertised renderers (Draw.io, LaTeX) were non-functional in the published image, and the migration UX had three concrete gaps.

This PR addresses all five before continuing with the remaining v0.1.0 series (release workflow, doctor subcommand, init subcommand, action.yml, README rewrite, tag).

### What was broken

| # | Issue | Severity |
|---|-------|----------|
| 1 | `DrawioRenderer` passed multi-token `DRAWIO_CMD` ("drawio --no-sandbox --disable-gpu") verbatim to `ProcessStartInfo.FileName`, looking for an executable literally named with the flags appended → `--render-drawio` broken in image | P0 |
| 2 | `LatexRenderer` still calls ImageMagick's `convert`, but PR #51 dropped ImageMagick from the runtime image (per design decision 2A) → `--render-latex` broken in image | P0 |
| 3 | Migration error message referenced a `v0.1.0 CHANGELOG` that didn't exist | P0 |
| 4 | `CliMigrationCheck` only matched `--mode <Value>` (space form), not `--mode=Value`, `--mode:Value`, or bare `--local` → users on the old syntax hit a bare "Unrecognized option" error | P1 |
| 5 | README + quickstart + admin/docker still taught the old `--mode`/`--local` syntax → users copy-pasting from docs hit the migration error on every command | P0 |

### What changed

**`src/ConfluenceSynkMD/Services/RendererCommandResolver.cs` (new):**
- Pure shell-style tokenizer with double-quote support. `Parse(envValue) -> (FileName, ArgsPrefix)`. Used by all three external-process renderers.

**`src/ConfluenceSynkMD/Services/DrawioRenderer.cs`:**
- `FindDrawioCommand` → `ResolveDrawioCommand` returning `(FileName, ArgsPrefix)?`. `DRAWIO_CMD` now accepts both bare names ("drawio") and multi-token values ("drawio --no-sandbox --disable-gpu").
- `Process.Start` is wrapped to translate `Win32Exception` (binary missing) into `InvalidOperationException("Draw.io CLI not found...")` so the existing test contract holds.

**`src/ConfluenceSynkMD/Services/PlantUmlRenderer.cs`:**
- `BuildCommand` now parses `PLANTUML_CMD` as cmd + args. `PLANTUML_JAR` (the `java -jar` convenience) still works exactly as before.

**`src/ConfluenceSynkMD/Services/LatexRenderer.cs`:**
- Replaces the ImageMagick `convert` call with `gs -sDEVICE=pngalpha -r300 -sOutputFile=...`. Drops the runtime ImageMagick dependency entirely (~80 MB image savings, no policy.xml workaround needed).
- Adds `LATEX_PDFLATEX_CMD` and `LATEX_GHOSTSCRIPT_CMD` env var support via the shared resolver. Defaults to `pdflatex` and `gs` from PATH.

**`src/ConfluenceSynkMD/Configuration/CliMigrationCheck.cs`:**
- Detects `--mode <Value>`, `--mode=Value`, `--mode:Value`, and bare `--local`.
- Migration message now inlines the migration table — no CHANGELOG link needed.

**`CHANGELOG.md`:**
- Seeded with an `[Unreleased]` section tracking the v0.1.0 work + migration table.

**Docs (find-replace):**
- `README.md`, `docs/en/quickstart.md`, `docs/de/quickstart.md`, `docs/en/admin/docker.md`, `docs/de/admin/docker.md` updated to use `upload` / `download` / `local` subcommand syntax.
- README's options table no longer lists `--mode` and `--local`. New "Subcommands" section explains the three verbs.
- Reference pages (`docs/{en,de}/reference/cli.md`, `user/*.md`, `cicd.md`) are intentionally left for the full README-rewrite PR.

### Test results

```
Bestanden!   : Fehler:     0, erfolgreich:   408, übersprungen:     6, gesamt:   414
```

Up from 382 (PR #52). +26 new tests:
- 13 `RendererCommandResolver` tests (single binary, multi-token, `java -jar`, quoted args, quoted paths, collapsed whitespace, tab separators, empty/null, `CombineArgs` cases).
- 13 `CliMigrationCheck` tests (equals form ×5, colon form ×3, `--local` detection ×2, inline table assertion, empty equals fallback, new-subcommand non-false-positive).

## Test plan

- [x] `dotnet build` clean
- [x] `dotnet test` green (408 pass / 6 skip / 0 fail)
- [ ] Manual: `docker build -t cs-test .` succeeds (PR #51's Dockerfile + this PR's renderer fixes)
- [ ] Manual: inside the built image, `dotnet ConfluenceSynkMD.dll upload --path X --conf-space Y --render-drawio --render-latex --render-plantuml` succeeds end-to-end
- [ ] Manual: `dotnet run -- --mode=Upload --path X` exits 2 with the migration table inlined in stderr

🤖 Generated with [Claude Code](https://claude.com/claude-code)