### PR TITLE
chore(release): v0.1.0 PR #7 — finalize CHANGELOG + fix trust-breaking inconsistencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,53 +5,107 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.1.0] - 2026-05-05
 
-This section tracks work toward the upcoming `v0.1.0` release: a portable
-Confluence publishing engine packaged as a single multi-arch Docker image
-with the full diagram toolchain (Mermaid, Draw.io, PlantUML, LaTeX) baked in.
+The first published, signed, multi-arch release. ConfluenceSynkMD now ships
+as a single Docker image with the full diagram toolchain preinstalled — no
+host-side Node, Java, TeX Live, or drawio installs required.
 
 ### Added
-- **Full diagram toolchain in the runtime image.** The Docker image now ships
-  Java + PlantUML, TeX Live + Ghostscript, and drawio-desktop alongside the
-  existing Node + mermaid-cli + Chromium. `--render-drawio`, `--render-plantuml`,
-  and `--render-latex` work out of the box without host-side installs.
+
+- **Full diagram toolchain in the runtime image.** The Docker image ships
+  Node.js 22 + `@mermaid-js/mermaid-cli` + Chromium (Mermaid), Java +
+  `plantuml` (PlantUML), TeX Live + Ghostscript (LaTeX), and drawio-desktop
+  + Xvfb (Draw.io). `--render-mermaid`, `--render-drawio`, `--render-plantuml`,
+  and `--render-latex` work out of the box.
 - **Container entrypoint with shared Xvfb display server.** `entrypoint.sh`
   starts a single `Xvfb :99` for the container's lifetime so drawio-desktop
-  (Electron) can run headlessly without restarting the display server per
-  diagram.
+  (Electron) can run headless without restarting the display server per
+  diagram. Polls `xdpyinfo` for up to 5 seconds before exec'ing dotnet to
+  close the startup race.
+- **`doctor` subcommand.** Runtime self-test that renders a small canary
+  diagram via every external-process renderer and probes the configured
+  Confluence instance via `IConfluenceHealthCheck`. Prints a green/red
+  checklist; exits 0 if every check passed, 1 otherwise. The release
+  workflow uses `doctor --renderers-only` as the smoke gate before pushing
+  any tag to GHCR.
+- **`init` subcommand.** First-run wizard. Reads `CONFLUENCE__*` env vars,
+  prompts for whatever is missing (refusing under `--non-interactive` or
+  when stdin is redirected, with a single-line error naming the missing
+  vars), validates against Confluence via `IConfluenceHealthCheck`, and
+  writes `.confluencesynkmd.json` (or `--config-out PATH`).
+- **`IConfluenceHealthCheck` service.** Lightweight reachability + auth
+  probe. Hits `GET /wiki/api/v2/spaces?limit=1` with a 10s default timeout;
+  falls back to v1 on 404; classifies responses into Healthy / NotConfigured
+  / AuthError / UpstreamError / NetworkError. Consumed by both `doctor`
+  and `init`.
+- **`RendererCommandResolver` shared helper.** Parses renderer command
+  env vars (`DRAWIO_CMD`, `PLANTUML_CMD`, `LATEX_PDFLATEX_CMD`,
+  `LATEX_GHOSTSCRIPT_CMD`) as shell-style command-plus-args strings.
+  Single-binary names (the previous contract) and multi-token invocations
+  (e.g. `xvfb-run -a drawio --no-sandbox --disable-gpu`) are both supported.
+- **Release workflow** at `.github/workflows/release-container.yml`.
+  Triggered on `v*.*.*` tag push: builds amd64 with `--load`, smoke-tests
+  via `doctor --renderers-only` BEFORE pushing, then builds + pushes
+  multi-arch (linux/amd64 + linux/arm64) to GHCR with provenance + SBOM
+  attestations. Signs the manifest list with cosign keyless OIDC and
+  immediately re-runs `cosign verify` to prove the user-facing
+  verification snippet works against the signed bytes.
+- **Emergency yank workflow** at `.github/workflows/release-yank.yml`.
+  Manual `workflow_dispatch` only; requires a written `reason` input that
+  lands in the step summary as an audit-log entry. Tag-only delete via
+  `gh api`; pinned digest pulls remain valid.
+- **GitHub Action wrapper** at `action.yml`. Composite action consuming
+  the published image. Inputs: `subcommand`, `path`, `conf-space`,
+  `conf-parent-id`, `keep-hierarchy`, `skip-update`, `image`, `extra-args`.
+  Mounts the workspace read-only for `upload`, writable for
+  `download`/`local`. Forwards `CONFLUENCE__*` env vars to the container.
 - **`DRAWIO_VERSION` Dockerfile pin** tracked monthly by
   `.github/workflows/docker-manual-pin-check.yml` alongside the existing
-  `MERMAID_CLI_VERSION` and `NODEJS_MAJOR` pins. The refresh PR body surfaces
-  arm64 `.deb` availability for the candidate version.
-- **Renderer cmd-args parsing.** `DRAWIO_CMD`, `PLANTUML_CMD`,
-  `LATEX_PDFLATEX_CMD`, and `LATEX_GHOSTSCRIPT_CMD` env vars now accept
-  multi-token values (e.g. `xvfb-run -a drawio --no-sandbox`) via a shared
-  `RendererCommandResolver` helper. Single-binary names (the previous contract)
-  remain valid.
-- **`.gitattributes`** forcing LF line endings on `.sh`, `Dockerfile`, and YAML
-  files so contributors on Windows do not accidentally introduce CRLF in
+  `MERMAID_CLI_VERSION` and `NODEJS_MAJOR` pins. The refresh PR body
+  surfaces arm64 `.deb` availability for the candidate version.
+- **`CliMigrationCheck`** detects users running the legacy `--mode <Value>`,
+  `--mode=Value`, `--mode:Value`, or bare `--local` syntax at startup and
+  prints an inline migration table before exiting with code 2. No silent
+  failures for users on the v0 CLI shape.
+- **`.gitattributes`** forcing LF line endings on `.sh`, `Dockerfile`, and
+  YAML files so Windows contributors do not introduce CRLF in
   Linux-target files.
 
 ### Changed
-- **CLI shape: subcommand tree.** `--mode Upload|Download|LocalExport` was
-  replaced by three top-level subcommands: `upload`, `download`, `local`.
-  This matches the idiomatic System.CommandLine pattern and clears the way
-  for the `doctor` and `init` subcommands shipping later in v0.1.0.
+
+- **CLI shape: subcommand tree.** `--mode Upload|Download|LocalExport`
+  was replaced by three top-level subcommands (`upload`, `download`, `local`)
+  alongside `doctor` and `init`. This matches the idiomatic
+  System.CommandLine pattern. Pre-1.0 makes the breaking change cheap;
+  the migration check above keeps users informed.
 - **`LatexRenderer` calls Ghostscript directly.** The PDF→PNG rasterization
   step previously delegated to ImageMagick's `convert`, which itself wraps
   Ghostscript. Calling `gs` directly drops the ImageMagick dependency from
   the runtime image (~80 MB) and removes the need for the `policy.xml`
-  workaround for PDF read defaults.
-- **Migration error message** for users hitting the legacy `--mode` / `--local`
-  flags now inlines the migration table instead of referencing an external
-  changelog entry.
+  workaround for ImageMagick's PDF read defaults. Adds
+  `LATEX_PDFLATEX_CMD` and `LATEX_GHOSTSCRIPT_CMD` env-var overrides.
+- **README headline** rewritten around the published Docker image. The new
+  Quick Start is three commands (`doctor`, `upload`, done). Also gains a
+  "What ships in the default image" coherence table and a GitHub Action
+  snippet.
 
 ### Removed
+
 - **`--mode` flag** (replaced by subcommands above).
 - **`--local` flag** (replaced by the `local` subcommand).
 - **ImageMagick** from the runtime image (Ghostscript handles PDF→PNG
-  natively; no functionality lost).
+  natively; no functionality lost). The previously documented
+  `policy.xml` workaround is no longer required.
+
+### Security
+
+- **Cosign-signed multi-arch image.** Every `v*.*.*` release publishes a
+  manifest-list digest signed by cosign keyless OIDC against the GitHub
+  Actions workflow that built it. SBOM (`docker/build-push-action`
+  `sbom: true`) and SLSA provenance (`provenance: mode=max`) attestations
+  are attached to the OCI manifest. Verify with the snippet pinned in
+  the release notes.
 
 ### Migration
 
@@ -65,3 +119,18 @@ with the full diagram toolchain (Mermaid, Draw.io, PlantUML, LaTeX) baked in.
 The binary detects the legacy syntax (including `--mode=Upload`,
 `--mode:Upload`, and bare `--local`) at startup and prints the migration
 table before exiting with code `2`. No silent failures.
+
+### Forward-only fix policy
+
+If a published `:0.1.x` release contains a critical bug, the project ships
+a `:0.1.x+1` patch and updates the moving `:0.1` tag. Pinned digest pulls
+(`docker pull ghcr.io/opendocsync/confluencesynkmd@sha256:...`) are never
+deleted. For security-grade incidents only (leaked credentials, actively
+dangerous regressions), the `release-yank.yml` workflow deletes a tag
+(not a digest). Routine bugs are fixed forward.
+
+### Image tag scheme
+
+For pre-1.0 releases, `metadata-action` emits exact-version (`0.1.0`),
+minor-track (`0.1`), and `sha-<short>` tags. `latest`, the major-track
+(`0`), and (`1`) are intentionally NOT created until v1.0.0 ships.

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ dotnet run --project src/ConfluenceSynkMD -- init
 ### As a GitHub Action
 
 ```yaml
-- uses: OpenDocSync/ConfluenceSynkMD@v1
+- uses: OpenDocSync/ConfluenceSynkMD@v0.1.0
   with:
     subcommand: upload
     path: docs
@@ -417,7 +417,7 @@ graph LR
 
 - **Confluence Cloud only** — Tested against Confluence Cloud REST API v2. Data Center / Server may work with `--api-version v1` and `--api-path ""`, but is not officially supported.
 - **No incremental download** — Download always fetches the full subtree; there is no delta sync in download mode.
-- **Diagram rendering requires external tools** — Mermaid needs Node.js + `@mermaid-js/mermaid-cli`, PlantUML needs a `plantuml` binary, Draw.io needs `drawio-export`. The Docker image includes Mermaid only.
+- **Diagram rendering requires external tools when running outside the Docker image** — Mermaid needs Node.js + `@mermaid-js/mermaid-cli`, PlantUML needs Java + the `plantuml` binary, Draw.io needs `drawio-desktop`, LaTeX needs TeX Live + Ghostscript. The published Docker image (`ghcr.io/opendocsync/confluencesynkmd:0.1`) ships every renderer preinstalled.
 - **No concurrent uploads** — Pages are uploaded sequentially to respect Confluence API rate limits and parent–child ordering.
 - **Markdown fidelity** — Not all Confluence macros have a Markdown equivalent. Download mode maps common structures but may lose macro-specific formatting.
 - **Single-space hierarchy** — `--keep-hierarchy` builds the page tree within a single space. Cross-space hierarchies are not supported (though individual documents can target different spaces via frontmatter).

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -18,7 +18,7 @@
   **A:** Cloud is the primary target. Data Center may partially work but is not officially supported.
 
 - **Q:** Why are some diagrams not rendered?
-  **A:** Some diagram modes require external binaries (for example `mmdc`, `plantuml`, `drawio-export`).
+  **A:** Some diagram modes require external binaries (for example `mmdc`, `plantuml`, `drawio-desktop`, TeX Live + Ghostscript). The published Docker image (`ghcr.io/opendocsync/confluencesynkmd:0.1`) ships every renderer preinstalled — run `docker run --rm ghcr.io/opendocsync/confluencesynkmd:0.1 doctor --renderers-only` to verify.
 
 - **Q:** Why was my page not updated?
   **A:** Check `--skip-update`, content hash behavior, and write-back metadata (`confluence-page-id`).

--- a/docs/de/admin/docker.md
+++ b/docs/de/admin/docker.md
@@ -295,16 +295,22 @@ Das Docker-Image enthält .NET, Node.js und mermaid-cli — eine konsistente, po
 
 ---
 
-## Image erweitern
+## Inhalt des Standard-Images
 
-Um zusätzliche Diagramm-Renderer hinzuzufügen:
+Das veröffentlichte `ghcr.io/opendocsync/confluencesynkmd:0.1` Image enthält alle vom Projekt versprochenen Renderer vorinstalliert:
 
-```dockerfile
-FROM confluencesynkmd AS base
+| Renderer | Engine |
+|---|---|
+| Mermaid | `@mermaid-js/mermaid-cli` + Chromium (Puppeteer) |
+| Draw.io | drawio-desktop (Electron, headless via Xvfb-once aus `entrypoint.sh`) |
+| PlantUML | `default-jre-headless` + das `plantuml` Paket |
+| LaTeX | TeX Live (`texlive-latex-base` + `texlive-latex-extra` + fonts-recommended) + Ghostscript direkt (ohne ImageMagick) |
 
-# PlantUML hinzufügen
-RUN apt-get update && apt-get install -y plantuml
+Zur Verifikation der Renderer-Gesundheit:
+`docker run --rm ghcr.io/opendocsync/confluencesynkmd:0.1 doctor --renderers-only`
 
-# Draw.io Export hinzufügen
-RUN npm install -g drawio-export
-```
+## Forward-Only-Fix-Politik
+
+Falls ein veröffentlichtes `:0.1.x` Release einen kritischen Bug enthält, liefert das Projekt einen `:0.1.x+1` Patch und aktualisiert den fortlaufenden `:0.1` Tag. Digest-Pulls (`docker pull ghcr.io/opendocsync/confluencesynkmd@sha256:...`) werden niemals gelöscht — Nutzer, die per Digest pinnen, haben einen Grund dafür.
+
+Nur für sicherheitskritische Vorfälle (geleakte Credentials, aktiv schädliche Regression) löscht der `release-yank.yml` Workflow einen Tag (nicht einen Digest) aus GHCR. Entscheidungskriterien sind in der Workflow-Datei dokumentiert.

--- a/docs/de/user/diagrams.md
+++ b/docs/de/user/diagrams.md
@@ -9,9 +9,11 @@ ConfluenceSynkMD kann Code-Blöcke verschiedener Diagramm-Sprachen in Bild-Anhä
 | Typ | Flag | Standard | Externes Tool |
 |---|---|---|---|
 | **Mermaid** | `--render-mermaid` | ✅ Aktiviert | `@mermaid-js/mermaid-cli` (Node.js) |
-| **Draw.io** | `--render-drawio` | ❌ Deaktiviert | `drawio-export` |
-| **PlantUML** | `--render-plantuml` | ❌ Deaktiviert | `plantuml`-Binary |
-| **LaTeX** | `--render-latex` | ❌ Deaktiviert | LaTeX-Distribution |
+| **Draw.io** | `--render-drawio` | ❌ Deaktiviert | `drawio-desktop` (headless via Xvfb) |
+| **PlantUML** | `--render-plantuml` | ❌ Deaktiviert | Java + das `plantuml` Paket |
+| **LaTeX** | `--render-latex` | ❌ Deaktiviert | LaTeX-Distribution + Ghostscript |
+
+> **Verwenden Sie das veröffentlichte Image?** Alle vier Renderer sind in `ghcr.io/opendocsync/confluencesynkmd:0.1` vorinstalliert — keine Host-Installation nötig. Mit `docker run --rm ghcr.io/opendocsync/confluencesynkmd:0.1 doctor --renderers-only` prüfen.
 
 ---
 

--- a/docs/en/admin/docker.md
+++ b/docs/en/admin/docker.md
@@ -300,16 +300,21 @@ The Dockerfile uses a **multi-stage build**:
 
 ---
 
-## Extending the Image
+## What ships in the default image
 
-To add additional diagram renderers, extend the Dockerfile:
+The published `ghcr.io/opendocsync/confluencesynkmd:0.1` image preinstalls every renderer claimed by the project:
 
-```dockerfile
-FROM confluencesynkmd AS base
+| Renderer | Backing engine |
+|---|---|
+| Mermaid | `@mermaid-js/mermaid-cli` + Chromium (Puppeteer) |
+| Draw.io | drawio-desktop (Electron, headless via Xvfb-once started by `entrypoint.sh`) |
+| PlantUML | `default-jre-headless` + the `plantuml` package |
+| LaTeX | TeX Live (`texlive-latex-base` + `texlive-latex-extra` + fonts-recommended) + Ghostscript directly (no ImageMagick) |
 
-# Add PlantUML
-RUN apt-get update && apt-get install -y plantuml
+Run `docker run --rm ghcr.io/opendocsync/confluencesynkmd:0.1 doctor --renderers-only` to verify all four renderers are healthy in the image you pulled.
 
-# Add Draw.io export
-RUN npm install -g drawio-export
-```
+## Forward-only fix policy
+
+If a published `:0.1.x` release contains a critical bug, the project ships a `:0.1.x+1` patch and updates the moving `:0.1` tag. Pinned digest pulls (`docker pull ghcr.io/opendocsync/confluencesynkmd@sha256:...`) are never deleted — users who pinned by digest pinned for a reason.
+
+For security-grade incidents only (leaked credentials, actively dangerous regression), the `release-yank.yml` workflow deletes a tag (not a digest) from GHCR. See the workflow file for the decision criteria.

--- a/docs/en/user/diagrams.md
+++ b/docs/en/user/diagrams.md
@@ -9,9 +9,11 @@ ConfluenceSynkMD can render code blocks for various diagram languages into image
 | Type | Flag | Default | External Tool Required |
 |---|---|---|---|
 | **Mermaid** | `--render-mermaid` | ✅ Enabled | `@mermaid-js/mermaid-cli` (Node.js) |
-| **Draw.io** | `--render-drawio` | ❌ Disabled | `drawio-export` |
-| **PlantUML** | `--render-plantuml` | ❌ Disabled | `plantuml` binary |
-| **LaTeX** | `--render-latex` | ❌ Disabled | LaTeX distribution |
+| **Draw.io** | `--render-drawio` | ❌ Disabled | `drawio-desktop` (run headless via Xvfb) |
+| **PlantUML** | `--render-plantuml` | ❌ Disabled | Java + the `plantuml` package |
+| **LaTeX** | `--render-latex` | ❌ Disabled | LaTeX distribution + Ghostscript |
+
+> **Running the published image?** All four renderers ship preinstalled in `ghcr.io/opendocsync/confluencesynkmd:0.1` — no host-side installation required. Run `docker run --rm ghcr.io/opendocsync/confluencesynkmd:0.1 doctor --renderers-only` to verify.
 
 ---
 
@@ -57,7 +59,13 @@ Enable Draw.io rendering to convert Draw.io XML code blocks into images:
 
 ### Prerequisites
 
-Install `drawio-export` or use the Docker image which can be extended to include it.
+Install `drawio-desktop` (an Electron app) and arrange a display server (Xvfb on Linux). The simpler path is the published Docker image, which preinstalls drawio-desktop and starts Xvfb on `:99` for the container's lifetime via `entrypoint.sh`. To use it manually, set `DRAWIO_CMD` to a multi-token invocation:
+
+```bash
+export DRAWIO_CMD="xvfb-run -a drawio --no-sandbox --disable-gpu"
+```
+
+The `DrawioRenderer` parses multi-token env values via `RendererCommandResolver`.
 
 ---
 

--- a/src/ConfluenceSynkMD/ETL/Load/LocalOnlyLoadStep.cs
+++ b/src/ConfluenceSynkMD/ETL/Load/LocalOnlyLoadStep.cs
@@ -8,7 +8,7 @@ namespace ConfluenceSynkMD.ETL.Load;
 /// <summary>
 /// Saves converted documents as Confluence Storage Format (CSF) files
 /// to the local filesystem without making any API calls.
-/// Used when --mode LocalExport or --local flag is set.
+/// Used when the `local` subcommand is invoked (SyncMode.LocalExport).
 /// </summary>
 public sealed class LocalOnlyLoadStep : IPipelineStep
 {

--- a/src/ConfluenceSynkMD/Services/DrawioRenderer.cs
+++ b/src/ConfluenceSynkMD/Services/DrawioRenderer.cs
@@ -5,7 +5,11 @@ namespace ConfluenceSynkMD.Services;
 
 /// <summary>
 /// Renders Draw.io (diagrams.net) XML content to PNG or SVG images.
-/// Requires the Draw.io Desktop app or drawio-export CLI tool to be available.
+/// Requires drawio-desktop on PATH (or via <c>DRAWIO_CMD</c>). On Linux it
+/// runs headless under Xvfb — the published Docker image starts an Xvfb-once
+/// instance via <c>entrypoint.sh</c> and sets <c>DISPLAY=:99</c>;
+/// outside Docker, set <c>DRAWIO_CMD="xvfb-run -a drawio --no-sandbox --disable-gpu"</c>
+/// (multi-token values are parsed by <see cref="RendererCommandResolver"/>).
 /// </summary>
 public sealed class DrawioRenderer : IDiagramRenderer
 {

--- a/tests/ConfluenceSynkMD.Tests/Integration/DiagramRenderingIntegrationTests.cs
+++ b/tests/ConfluenceSynkMD.Tests/Integration/DiagramRenderingIntegrationTests.cs
@@ -102,7 +102,7 @@ public class DiagramRenderingIntegrationTests
         format.Should().Be("svg");
     }
 
-    [Fact(Skip = "Requires pdflatex and ImageMagick convert installed")]
+    [Fact(Skip = "Requires pdflatex and ghostscript installed")]
     public async Task LatexRenderer_Should_ProducePngBytes()
     {
         var logger = Substitute.For<ILogger>();
@@ -116,7 +116,7 @@ public class DiagramRenderingIntegrationTests
         bytes[..4].Should().BeEquivalentTo(new byte[] { 0x89, 0x50, 0x4E, 0x47 }, "PNG magic bytes");
     }
 
-    [Fact(Skip = "Requires pdflatex and ImageMagick convert installed")]
+    [Fact(Skip = "Requires pdflatex and ghostscript installed")]
     public async Task LatexRenderer_Should_CleanupTempFiles()
     {
         var logger = Substitute.For<ILogger>();


### PR DESCRIPTION
## Summary

Final PR before tagging v0.1.0. Closes the three P0 blockers from the cumulative end-to-end review and sweeps related stale references that survived the earlier PRs.

### P0 fixes

1. **`README.md:109`** Action snippet referenced `@v1`, which the v0.1.0 release workflow does not publish (it intentionally stops at the minor-track `:0.1` until v1.0.0). Changed to `@v0.1.0`.
2. **`README.md:420`** Limitations section claimed "Docker image includes Mermaid only", contradicting the new "What ships in the default image" table four screens above. Rewrote to state the published image preinstalls every renderer.
3. **`CHANGELOG.md`** was still `[Unreleased]` and missing four major shipped items (`doctor`, `init`, GitHub Action, release/yank workflows). Renamed to `[0.1.0] - 2026-05-05` with full Added/Changed/Removed/Security sections plus the migration table and the forward-only fix policy.

### P1 sweep (the same trust-breaking story propagated through other docs)

- `docs/{en,de}/admin/docker.md`: replaced the stale "Extending the Image" section (which still told users to `npm install -g drawio-export`) with a coherence table + forward-only fix policy.
- `docs/{en,de}/user/diagrams.md`: updated the renderer engines table (drawio-desktop with Xvfb, plantuml + JRE, TeX Live + Ghostscript). Rewrote Draw.io prerequisites (was: install long-deprecated drawio-export CLI).
- `SUPPORT.md` FAQ: drawio-export → drawio-desktop + TeX Live + Ghostscript; points at `doctor`.
- `src/ConfluenceSynkMD/ETL/Load/LocalOnlyLoadStep.cs` xmldoc: `--mode/--local` → `local` subcommand.
- `src/ConfluenceSynkMD/Services/DrawioRenderer.cs` xmldoc: drawio-export CLI → drawio-desktop + Xvfb-once.
- `tests/.../DiagramRenderingIntegrationTests.cs`: skip messages now say "pdflatex and ghostscript" (was: "pdflatex and ImageMagick convert").

After this PR merges, the repo is ready for `git tag v0.1.0 && git push origin v0.1.0` to trigger the release workflow.

### CI

- `dotnet build` clean (0 errors).
- No source-code semantic changes — every fix is text/xmldoc/CHANGELOG. Existing tests still pass; coverage threshold unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)