### PR TITLE
fix(docker): bump DRAWIO_VERSION 26.0.0 -> 29.7.9 (real upstream version)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ FROM mcr.microsoft.com/dotnet/aspnet:10.0@sha256:52dcfb4225fda614c38ba5997a4ec72
 
 ARG NODEJS_MAJOR=22
 ARG MERMAID_CLI_VERSION=11.12.0
-ARG DRAWIO_VERSION=26.0.0
+ARG DRAWIO_VERSION=29.7.9
 ARG TARGETARCH
 
 # Dependabot tracks Docker base image updates (FROM).


### PR DESCRIPTION
## Summary

Hot-fix for the failed v0.1.0 release. The release-container.yml run for v0.1.0 (run 25347796519) failed at the amd64 build step:

\`\`\`
#19 0.483 curl: (22) The requested URL returned error: 404
ERROR: process \"...curl -fsSL ... drawio-amd64-26.0.0.deb...\" did not complete successfully: exit code: 22
\`\`\`

\`v26.0.0\` was never released by jgraph. Real latest stable: **v29.7.9** (verified via \`gh api repos/jgraph/drawio-desktop/releases\`; ships both \`drawio-amd64-29.7.9.deb\` and \`drawio-arm64-29.7.9.deb\` assets).

The smoke gate held: no image was ever pushed to GHCR. This is pre-release housekeeping.

After merge:

1. Delete the dangling \`v0.1.0\` tag from origin (\`git push --delete origin v0.1.0\`).
2. Re-tag \`v0.1.0\` from main HEAD.
3. Push the new tag → fresh release workflow run with the correct pin.

The monthly \`docker-manual-pin-check.yml\` workflow added in PR #51 is the path for keeping this fresh going forward — it queries the GitHub releases API and only opens a PR if both an amd64 .deb is available and the latest tag matches the SemVer pattern.