### PR TITLE
fix(doctor): drawio canary needs page-level mxfile attributes (v0.1.0 retry #2)

### DIFF
--- a/src/ConfluenceSynkMD/Commands/DoctorCommand.cs
+++ b/src/ConfluenceSynkMD/Commands/DoctorCommand.cs
@@ -128,11 +128,22 @@ public sealed class DoctorCommand
     private const string PlantumlCanary =
         "@startuml\nA -> B\n@enduml";
 
+    // Real drawio-desktop will silently exit 0 without producing output when
+    // the input mxfile is missing the page-level attributes the editor would
+    // normally write (dx/dy/grid/pageWidth/pageHeight). This canary mirrors
+    // the exact shape diagrams.net writes for an empty new page.
     private const string DrawioCanary =
-        "<mxfile host=\"Doctor\"><diagram><mxGraphModel><root>" +
+        "<mxfile host=\"app.diagrams.net\" version=\"22.0.0\">" +
+        "<diagram name=\"Page-1\" id=\"doctor\">" +
+        "<mxGraphModel dx=\"800\" dy=\"600\" grid=\"1\" gridSize=\"10\" guides=\"1\" " +
+        "tooltips=\"1\" connect=\"1\" arrows=\"1\" fold=\"1\" page=\"1\" pageScale=\"1\" " +
+        "pageWidth=\"850\" pageHeight=\"1100\" math=\"0\" shadow=\"0\">" +
+        "<root>" +
         "<mxCell id=\"0\"/><mxCell id=\"1\" parent=\"0\"/>" +
-        "<mxCell id=\"2\" value=\"A\" vertex=\"1\" parent=\"1\">" +
-        "<mxGeometry x=\"0\" y=\"0\" width=\"40\" height=\"20\" as=\"geometry\"/></mxCell>" +
+        "<mxCell id=\"2\" value=\"doctor\" style=\"rounded=0;whiteSpace=wrap;html=1;\" " +
+        "vertex=\"1\" parent=\"1\">" +
+        "<mxGeometry x=\"40\" y=\"40\" width=\"120\" height=\"60\" as=\"geometry\"/>" +
+        "</mxCell>" +
         "</root></mxGraphModel></diagram></mxfile>";
 
     private const string LatexCanary = @"\frac{1}{2}";

--- a/src/ConfluenceSynkMD/Services/DrawioRenderer.cs
+++ b/src/ConfluenceSynkMD/Services/DrawioRenderer.cs
@@ -71,6 +71,20 @@ public sealed class DrawioRenderer : IDiagramRenderer
                 throw new InvalidOperationException($"Draw.io export failed (exit {process.ExitCode}): {stderr}");
             }
 
+            // drawio-desktop sometimes exits 0 without producing the output file
+            // — typically when the input mxfile is missing page-level metadata
+            // the editor would normally write (dx/dy/pageWidth/pageHeight). Surface
+            // an actionable error rather than a bare FileNotFoundException.
+            if (!File.Exists(outputFile))
+            {
+                var stdout = await process.StandardOutput.ReadToEndAsync(ct);
+                var stderr = await process.StandardError.ReadToEndAsync(ct);
+                throw new InvalidOperationException(
+                    $"Draw.io exited 0 but produced no output at '{outputFile}'. " +
+                    "This usually means the input mxfile is missing required page-level attributes. " +
+                    $"stdout: {stdout.Trim()}; stderr: {stderr.Trim()}");
+            }
+
             var imageBytes = await File.ReadAllBytesAsync(outputFile, ct);
             _logger.Debug("Draw.io diagram rendered: {Size} bytes ({Format}).", imageBytes.Length, outputFormat);
             return (imageBytes, outputFormat);


### PR DESCRIPTION
## Summary

Second hot-fix on the v0.1.0 release. After PR #60 fixed the DRAWIO_VERSION pin (26.0.0 was never published; bumped to 29.7.9), the build succeeded but the smoke step failed:

\`\`\`
[ OK ]  Mermaid
[FAIL]  Draw.io
         Could not find file '/tmp/ConfluenceSynkMD-drawio/diagram-5a3d8cd40cea480280aa9bbdc50db662.png'.
[ OK ]  PlantUML
[ OK ]  LaTeX
\`\`\`

drawio-desktop exited with code 0 but never produced the output file. Root cause: the canary mxfile in \`DoctorCommand.cs\` was a minimal shape (\`<mxfile host="Doctor"><diagram>...\`) that the editor would never write. drawio-desktop's headless export silently rejects mxfiles missing the page-level attributes (dx/dy/grid/pageWidth/pageHeight).

## Two changes

1. **\`DoctorCommand.cs\` canary** — replace with a fully-formed mxfile mirroring what diagrams.net writes for a new empty page (host=\`app.diagrams.net\`, named diagram, full \`<mxGraphModel>\` page metadata, vertex with a real \`style=\`).
2. **\`DrawioRenderer.cs\` error message** — when \`Process.Start\` exits 0 but produces no output file, throw \`InvalidOperationException\` with the actionable hint and drawio's stdout/stderr instead of letting \`File.ReadAllBytesAsync\` throw a bare \`FileNotFoundException\`. Closes a future-debugging gap.

The release pipeline's smoke gate held both runs — nothing was pushed to GHCR. After this PR merges, the dangling \`v0.1.0\` tag will be deleted and re-pushed pointing at the new \`main\` HEAD; that retriggers the release workflow with the corrected canary.

## Test plan

- [x] \`dotnet build\` clean.
- [ ] Manual (post-merge): the new release workflow run reaches the smoke step and \`doctor --renderers-only\` returns 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)