### PR TITLE
fix(docker): drawio shim — Electron flags BEFORE drawio CLI args (v0.1.0 retry #3)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ ARG TARGETARCH
 
 ENV PUPPETEER_CACHE_DIR=/app/.cache/puppeteer \
     DISPLAY=:99 \
-    DRAWIO_CMD="drawio --no-sandbox --disable-gpu"
+    DRAWIO_CMD=drawio-headless
 
 # System packages.
 # - Chromium runtime libs for Puppeteer (Mermaid renderer).
@@ -117,6 +117,15 @@ RUN echo '{"args": ["--no-sandbox", "--disable-setuid-sandbox"]}' > /app/puppete
 # xvfb-run startup cost. See entrypoint.sh for the full startup contract.
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
+
+# drawio-desktop invocation wrapper. Electron flags (--no-sandbox /
+# --disable-gpu / --disable-dev-shm-usage) MUST appear before drawio's own
+# CLI options or commander.js mis-parses them as positional input paths
+# and exits with "Error: input file/directory not found". The shim exec's
+# drawio with the Electron flags, then "$@" forwards the renderer's export
+# args. ENV DRAWIO_CMD=drawio-headless points DrawioRenderer here.
+COPY drawio-headless.sh /usr/local/bin/drawio-headless
+RUN chmod +x /usr/local/bin/drawio-headless
 
 COPY --from=build /app/publish .
 

--- a/drawio-headless.sh
+++ b/drawio-headless.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+# /usr/local/bin/drawio-headless — invocation wrapper for drawio-desktop
+# inside the published Docker image.
+#
+# drawio-desktop's CLI parser (commander.js) does NOT consume Electron flags
+# like --no-sandbox / --disable-gpu before its own option parsing — empirically
+# they bleed into commander's positional-argument list and trigger
+# "Error: input file/directory not found" when the renderer also passes a
+# real input path. Fix: wrap drawio so the Electron flags appear BEFORE any
+# user args via shell exec, and the renderer just calls `drawio-headless`
+# with its export options. Eliminates the multi-token DRAWIO_CMD path.
+#
+# Display server: the container's entrypoint.sh starts a single Xvfb on
+# :99 for the container's lifetime; this script inherits DISPLAY=:99 from
+# the Dockerfile's ENV.
+
+exec /usr/bin/drawio \
+  --no-sandbox \
+  --disable-gpu \
+  --disable-dev-shm-usage \
+  "$@"


### PR DESCRIPTION
## Summary

Third hot-fix on the v0.1.0 release. The smoke gate has held all three previous attempts — no broken image has reached GHCR.

| Run | Failure | Hot-fix |
|---|---|---|
| 25347796519 | curl 404 on \`drawio-amd64-26.0.0.deb\` | PR #60: pin → 29.7.9 |
| 25348975404 | drawio exit 0, no output, minimal canary | PR #61: full mxfile canary |
| 25349672599 | "Error: input file/directory not found" buried in dbus noise | **this PR** |

### Root cause of the third failure

drawio-desktop's commander.js parser does not consume Electron flags before its own option parsing. \`--no-sandbox\` and \`--disable-gpu\` bled into commander's positional-argument list, where drawio looked for a file literally named \`--no-sandbox\` and exited with \`Error: input file/directory not found\`.

The PR #51 design had a \`/usr/local/bin/drawio-headless\` shim for exactly this reason; I dropped it during the Xvfb-once refactor on the (incorrect) assumption that \`DRAWIO_CMD="drawio --no-sandbox --disable-gpu"\` through the renderer's cmd-args parser would be equivalent. The parser does tokenize correctly — but commander then re-parses and mis-classifies.

### Fix

- **\`drawio-headless.sh\`** at the repo root, installed to \`/usr/local/bin/drawio-headless\`, mode 0755. Exec's drawio with Electron flags as the FIRST argv tokens (so Electron's main process consumes them) before \`"$@"\` appends the renderer's export args. Adds \`--disable-dev-shm-usage\` (third Electron flag commonly required inside containers).
- **\`Dockerfile\`**: \`COPY drawio-headless.sh\` + \`chmod +x\`; \`ENV DRAWIO_CMD=drawio-headless\` (single-binary form). Eliminates the parse-order ambiguity entirely.

After this PR merges, the dangling \`v0.1.0\` tag is deleted and re-pushed pointing at the new \`main\` HEAD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)