### PR TITLE
fix(drawio): use ProcessStartInfo.ArgumentList instead of Arguments string (v0.1.0 retry #4)

### DIFF
--- a/src/ConfluenceSynkMD/Services/DrawioRenderer.cs
+++ b/src/ConfluenceSynkMD/Services/DrawioRenderer.cs
@@ -49,17 +49,40 @@ public sealed class DrawioRenderer : IDiagramRenderer
                     "Draw.io CLI not found. Install 'drawio-desktop' or set DRAWIO_CMD environment variable.");
             }
 
-            var perCallArgs = $"--export --format {outputFormat} --output \"{outputFile}\" \"{inputFile}\"";
-
+            // Use ArgumentList instead of Arguments string. Each call adds one
+            // argv token verbatim — no shell-style quote/whitespace parsing,
+            // no risk of literal `"` characters leaking into the argv that
+            // drawio receives. The previous string-form caused drawio's
+            // commander parser to see `"/tmp/...drawio"` (with embedded quotes)
+            // as the input path and fail with "Error: input file/directory not found".
             var psi = new ProcessStartInfo
             {
                 FileName = resolved.Value.FileName,
-                Arguments = RendererCommandResolver.CombineArgs(resolved.Value.ArgsPrefix, perCallArgs),
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
                 UseShellExecute = false,
                 CreateNoWindow = true,
             };
+
+            // Forward any tokens from DRAWIO_CMD's args prefix (e.g. when an
+            // operator overrides the env var with a multi-token wrapper).
+            if (!string.IsNullOrEmpty(resolved.Value.ArgsPrefix))
+            {
+                foreach (var token in SplitTokens(resolved.Value.ArgsPrefix))
+                    psi.ArgumentList.Add(token);
+            }
+
+            psi.ArgumentList.Add("--export");
+            psi.ArgumentList.Add("--format");
+            psi.ArgumentList.Add(outputFormat);
+            psi.ArgumentList.Add("--output");
+            psi.ArgumentList.Add(outputFile);
+            psi.ArgumentList.Add(inputFile);
+
+            _logger.Debug(
+                "Draw.io invocation: {FileName} {Args}",
+                psi.FileName,
+                string.Join(' ', psi.ArgumentList));
 
             using var process = StartDrawioProcess(psi);
 
@@ -173,6 +196,34 @@ public sealed class DrawioRenderer : IDiagramRenderer
         }
 
         return null;
+    }
+
+    private static IEnumerable<string> SplitTokens(string input)
+    {
+        // Reuse RendererCommandResolver's tokenizer indirectly by parsing the
+        // string as a fake "cmd args" pair. The first token comes back as
+        // FileName and the rest as ArgsPrefix; we only need the rest split
+        // back into tokens, so we synthesize a pseudo-prefix and split it.
+        if (string.IsNullOrWhiteSpace(input))
+            return Array.Empty<string>();
+
+        // Cheap shell-style split: respect double-quoted spans, drop the
+        // grouping quotes. Same rules as RendererCommandResolver.Parse uses.
+        var result = new List<string>();
+        var current = new System.Text.StringBuilder();
+        var inQuote = false;
+        foreach (var c in input)
+        {
+            if (c == '"') { inQuote = !inQuote; continue; }
+            if (char.IsWhiteSpace(c) && !inQuote)
+            {
+                if (current.Length > 0) { result.Add(current.ToString()); current.Clear(); }
+                continue;
+            }
+            current.Append(c);
+        }
+        if (current.Length > 0) result.Add(current.ToString());
+        return result;
     }
 
     private static void TryDeleteFile(string path)


### PR DESCRIPTION
## Summary

Fourth hot-fix on the v0.1.0 release. Smoke gate has held all four prior attempts — no broken image has reached GHCR.

| Run | Failure | Hot-fix |
|---|---|---|
| 25347796519 | curl 404 on \`drawio-amd64-26.0.0.deb\` | PR #60: pin → 29.7.9 |
| 25348975404 | drawio exit 0, no output, minimal canary | PR #61: full mxfile canary |
| 25349672599 | "input file/directory not found" buried in dbus noise | PR #62: drawio-headless shim |
| 25349998285 | Same error, even with the shim | **this PR** |

### Real root cause

The renderer built its argv as a quoted Arguments **string** —
\`--export --format png --output "/tmp/X.png" "/tmp/Y.drawio"\` —
and passed that to \`ProcessStartInfo.Arguments\`. On Linux .NET 10,
the embedded \`"\` characters leak into argv. drawio's commander parser
then sees the path with literal quotes and fails to find the file.

The PR #62 shim closed a different (theoretical) issue — Electron flag
ordering — but didn't address the real bug because both runs use the
same renderer code path that produces the broken Arguments string.

### Fix

Switch to \`ProcessStartInfo.ArgumentList\`:
- Each token added explicitly. No string parsing. No quote characters in argv.
- DRAWIO_CMD args-prefix tokens (when an operator overrides the env var with a multi-token wrapper) flow through a shell-style tokenizer (\`SplitTokens\`) that mirrors \`RendererCommandResolver.Parse\`.
- New debug log line prints \`FileName + args\` before Process.Start so the next failure (if any) shows exactly what drawio receives.

### Test plan

- [x] \`dotnet build\` clean.
- [x] \`dotnet test\` green: 432 pass / 6 skip / 0 fail. No regressions on existing DrawioRendererTests.
- [ ] Manual (post-merge): the new release run reaches the smoke step and \`doctor --renderers-only\` returns 0 with all four renderers green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)