### PR TITLE
fix(docker): drawio-headless wraps with dbus-run-session (v0.1.0 retry #5)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,9 +75,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     texlive-fonts-recommended \
     ghostscript \
     poppler-utils \
-    # Headless display server for drawio-desktop (Electron app)
+    # Headless display server for drawio-desktop (Electron app).
+    # `dbus` provides a temporary session bus via `dbus-run-session` that
+    # the shim wraps drawio with — without it, Electron's IPC fails to
+    # initialize and drawio's commander parser falls back to a code path
+    # that emits "Error: input file/directory not found" with exit 0.
     xvfb \
     x11-utils \
+    dbus \
+    dbus-x11 \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Node.js LTS from explicitly configured NodeSource APT repository.

--- a/drawio-headless.sh
+++ b/drawio-headless.sh
@@ -2,20 +2,22 @@
 # /usr/local/bin/drawio-headless — invocation wrapper for drawio-desktop
 # inside the published Docker image.
 #
-# drawio-desktop's CLI parser (commander.js) does NOT consume Electron flags
-# like --no-sandbox / --disable-gpu before its own option parsing — empirically
-# they bleed into commander's positional-argument list and trigger
-# "Error: input file/directory not found" when the renderer also passes a
-# real input path. Fix: wrap drawio so the Electron flags appear BEFORE any
-# user args via shell exec, and the renderer just calls `drawio-headless`
-# with its export options. Eliminates the multi-token DRAWIO_CMD path.
-#
-# Display server: the container's entrypoint.sh starts a single Xvfb on
-# :99 for the container's lifetime; this script inherits DISPLAY=:99 from
-# the Dockerfile's ENV.
+# drawio-desktop is an Electron app. It expects:
+#   1. A display server. Provided by entrypoint.sh's Xvfb on :99,
+#      inherited via DISPLAY=:99 in the Dockerfile ENV.
+#   2. A session-level dbus. Without it, parts of Electron's IPC fail to
+#      initialize and drawio's commander parser falls into a fallback path
+#      that emits "Error: input file/directory not found" and exits 0.
+#      `dbus-run-session` (from the dbus-x11 package) creates a private
+#      session bus for the duration of the wrapped command and tears it
+#      down on exit.
+#   3. Sandbox + GPU disabled. Both must appear BEFORE drawio's own CLI
+#      flags so Electron's main process consumes them before commander
+#      starts parsing the export options.
 
-exec /usr/bin/drawio \
-  --no-sandbox \
-  --disable-gpu \
-  --disable-dev-shm-usage \
-  "$@"
+exec dbus-run-session -- \
+  /usr/bin/drawio \
+    --no-sandbox \
+    --disable-gpu \
+    --disable-dev-shm-usage \
+    "$@"


### PR DESCRIPTION
## Summary

Fifth hot-fix. The smoke gate has held all five runs — no broken image ever reached GHCR.

| Run | Theory tested | Hot-fix |
|---|---|---|
| 25347796519 | Wrong DRAWIO_VERSION pin | PR #60: pin → 29.7.9 |
| 25348975404 | Minimal canary mxfile | PR #61: full mxfile |
| 25349672599 | Electron-flag misordering | PR #62: drawio-headless shim |
| 25349998285 | Quote leakage in argv | (no fix; theory was right but code path didn't reach the renderer because shim was active) |
| 25350406391 | Argv via .Arguments string | PR #63: ArgumentList |
| (this PR) | dbus session bus init failure | dbus-run-session in shim |

### Root cause analysis

The PR #63 \`ArgumentList\` switch ruled out quote leakage as the cause. Same error persisted: dbus init errors, then "Error: input file/directory not found" with exit 0.

The actual cause: drawio-desktop is an Electron app whose IPC requires a **session-level dbus**. Without one, Electron's setup fails partway through and drawio's commander parser falls into a fallback path that emits "input file/directory not found" — drawio thinks it succeeded so it exits 0. The dbus errors at the top of stderr were the real signal; the input/directory message was the symptom.

### Fix

- **Dockerfile**: install \`dbus\` + \`dbus-x11\` (provides \`dbus-run-session\`).
- **drawio-headless.sh**: \`exec dbus-run-session -- /usr/bin/drawio --no-sandbox --disable-gpu --disable-dev-shm-usage "$@"\`. \`dbus-run-session\` creates a private session bus for the duration of the wrapped command and tears it down on exit.

### If THIS still fails

The fallback plan: drop drawio from the smoke gate. The image still ships drawio (per the design's "complete promise" decision) but the doctor canary becomes informational for that renderer. Documented as a known v0.1.0 limitation; v0.1.1 follow-up properly debugs drawio-desktop's container-headless behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)