### PR TITLE
fix(release): lowercase IMAGE_NAME before cosign sign (v0.1.0 retry #7)

### DIFF
--- a/.github/workflows/release-container.yml
+++ b/.github/workflows/release-container.yml
@@ -35,6 +35,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      # OCI repository names must be lowercase. `github.repository_owner`
+      # preserves case ("OpenDocSync"), which docker/build-push-action
+      # auto-lowercases on push but cosign does NOT — it rejects mixed-case
+      # references with "could not parse reference". Compute a lowercase
+      # IMAGE_NAME here and overwrite the env so every downstream step
+      # (metadata-action, build-push-action, cosign sign/verify, release
+      # notes) sees the same lowercase value.
+      - name: Compute lowercase image name
+        run: |
+          OWNER_LC=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          echo "IMAGE_NAME=ghcr.io/${OWNER_LC}/confluencesynkmd" >> "$GITHUB_ENV"
+
       - name: Set up QEMU (multi-arch buildx)
         uses: docker/setup-qemu-action@v3
         with:


### PR DESCRIPTION
## Summary

Hot-fix #7. Run \`25351114284\` successfully built + pushed multi-arch v0.1.0 to GHCR (drawio out of smoke gate per #65), but **cosign sign** failed:

\`\`\`
Error: signing [ghcr.io/OpenDocSync/confluencesynkmd@sha256:...]:
parsing reference: could not parse reference
\`\`\`

OCI distribution requires repository names lowercase. \`docker/build-push-action\` lowercases internally; cosign doesn't and rejects mixed-case at the parser level.

### Fix

New step computes \`IMAGE_NAME=ghcr.io/$(echo $OWNER | tr A-Z a-z)/confluencesynkmd\` and writes it to \`$GITHUB_ENV\` before any subsequent step uses the env var.

### Note on the currently-published unsigned image

The image at \`sha256:07299e9f...\` is on GHCR right now under tags \`:0.1.0\`, \`:0.1\`, \`:sha-5f5a123\` — but unsigned. After this PR merges and the workflow re-runs:
- \`build-push-action\` with cache produces a deterministic digest (no source changes)
- The \`:0.1.0\` / \`:0.1\` tags get re-pointed at that digest
- \`cosign sign\` runs against the lowercase reference and succeeds
- GitHub Release published with the verify command

The previously-pushed unsigned manifest stays orphaned on GHCR per the forward-only fix policy. Anyone who pinned \`@sha256:07299e9f...\` between now and the re-tag has an unsigned reference, but tag-based pulls (the README's primary path) move to the signed digest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)